### PR TITLE
Fix invalid directory in sample file

### DIFF
--- a/conf/datasources.ini.sample
+++ b/conf/datasources.ini.sample
@@ -18,7 +18,7 @@
 ; dateGranularity = auto
 ; harvestedIdLog = harvest.log
 ; verbose = false
-; solrTransformation = conf/oai_dc.properties
+; solrTransformation = oai_dc.properties
 ;
 ; The section_name may be passed to harvest_oai.php as a parameter to harvest only
 ; records from that source.  This is also the directory name that records will be
@@ -106,5 +106,5 @@
 ;injectDate = "datestamp"
 ;institution = MyInst
 ;format = dc
-;solrTransformation = conf/oai_dc.properties
+;solrTransformation = oai_dc.properties
 


### PR DESCRIPTION
Just fixing a trivial bug which was causing me some confusion: the given example option is "conf/oai_dc.properties" which tries to read from the non-existant dir "RecordManager/transformations/conf/"

 Mainly to try out an actual pull request :p
