### PR TITLE
use single comment style in sample configuration

### DIFF
--- a/conf/recordmanager.ini.sample
+++ b/conf/recordmanager.ini.sample
@@ -49,23 +49,23 @@ set_definitions = oai-pmh-sets.ini
 ;ead = NdlEadRecord
 
 [Geocoding]
-// Please see http://wiki.openstreetmap.org/wiki/Nominatim_usage_policy before using Nominatim
+; Please see http://wiki.openstreetmap.org/wiki/Nominatim_usage_policy before using Nominatim
 geocoder = NominatimGeocoder
-// Milliseconds to wait between requests (set to at least 1000 when using OpenStreetMap's servers) 
+; Milliseconds to wait between requests (set to at least 1000 when using OpenStreetMap's servers)
 delay = 1500
 ;url = "http://nominatim.openstreetmap.org/search"
 ;email = "your@address"
 ;preferred_area = "-2.75,70.42,36.63,55.21"
-// Polygon simplification tolerance. GEOS and its PHP extension must be installed for simplification to be available
-// (see https://github.com/phayes/geoPHP/wiki/GEOS) 
+; Polygon simplification tolerance. GEOS and its PHP extension must be installed for simplification to be available
+; (see https://github.com/phayes/geoPHP/wiki/GEOS)
 ;simplification_tolerance = 0.001
-// Maximum number of polygon elements
+; Maximum number of polygon elements
 ;simplification_max_length = 1000
 
-// Solr field that contains the geocoding data
+; Solr field that contains the geocoding data
 solr_field = location_geo
-// Threshold governing whether a location is considered important. If such a location is found, locations with lower importance
-// are ignored. Default is 0.9.
+; Threshold governing whether a location is considered important. If such a location is found, locations with lower importance
+; are ignored. Default is 0.9.
 ;important_threshold = 0.8
 
 [Log]


### PR DESCRIPTION
Installation was a breeze, except for the mixed comment style in `recordmanager.ini.sample`. Maybe it's ok to use just one style?
