### PR TITLE
Remove <record> tag from ListIdentifiers

### DIFF
--- a/classes/OaiPmhProvider.php
+++ b/classes/OaiPmhProvider.php
@@ -832,15 +832,18 @@ EOF;
         );
         $date = $this->toOaiDate($record['updated']->sec);
         $status = $record['deleted'] ? ' status="deleted"' : '';
-        return <<<EOF
-    <record>
+
+        $result = <<<EOF
       <header$status>
         <identifier>$id</identifier>
         <datestamp>$date</datestamp>
 $setSpecs      </header>
-$metadata    </record>
-
 EOF;
+        if ($includeMetadata) {
+            return "<record>\n" . $result."\n" . $metadata . "</record>\n\n";
+        } else {
+            return $result."\n\n";
+	}
     }
 
     /**


### PR DESCRIPTION
Hello,

The OAI-PMH repository feature is easy to use and works well, but I noticed ListIdentifier return the <record> tags in the XML output, while it should maybe return a list of headers directly ? That's what in understood according to  
https://www.openarchives.org/OAI/openarchivesprotocol.html#ListIdentifiers

and to http://validator.oaipmh.com/#ListRecords

This pull request may fix the problem, I'm not in production with it yet and I don't have a lot of different use cases so I'm not sure about any possible side effects.

Regards,

Stephane