### PR TITLE
Remove mbid enrichment with mainauthor

### DIFF
--- a/src/RecordManager/Base/Enrichment/MusicBrainzEnrichment.php
+++ b/src/RecordManager/Base/Enrichment/MusicBrainzEnrichment.php
@@ -127,17 +127,6 @@ class MusicBrainzEnrichment extends Enrichment
                 $mbIds = array_merge($mbIds, $this->getMBIDs($query));
             }
         }
-        if (!$mbIds && ($author = $record->getMainAuthor())) {
-            $parts = explode(', ', $author, 2);
-            if (isset($parts[1])) {
-                $author = $parts[1] . ' ' . $parts[0];
-            }
-            $query = 'artistname:"' . addcslashes($author, "\"\\")
-                . '" AND releaseaccent:"'
-                . addcslashes($solrArray['title_short'], "\"\\")
-                . '"';
-            $mbIds = $this->getMBIDs($query, true);
-        }
         if ($mbIds) {
             $solrArray['mbid_str_mv'] = $mbIds;
         }


### PR DESCRIPTION
Encrichment with mainauthor fails on classic releases as there might be many same named releases with same authors present. Due to this, some records might get wrong MBID and show wrong release cover.

Lets wait for response from outi.