### PR TITLE
Modify ForwardAuthority record IDs to resemble Forward record IDs.

### DIFF
--- a/src/RecordManager/Base/Record/ForwardAuthority.php
+++ b/src/RecordManager/Base/Record/ForwardAuthority.php
@@ -68,7 +68,7 @@ class ForwardAuthority extends Base
     public function getID()
     {
         $doc = $this->getMainElement();
-        return (string)$doc->AgentIdentifier->IDTypeName . ':'
+        return (string)$doc->AgentIdentifier->IDTypeName . '_'
             . (string)$doc->AgentIdentifier->IDValue;
     }
 

--- a/src/RecordManager/Finna/Record/Forward.php
+++ b/src/RecordManager/Finna/Record/Forward.php
@@ -279,9 +279,9 @@ class Forward extends \RecordManager\Base\Record\Forward
                 }
             }
             $result['names'][] = $name;
-            $id = (string)$agent->AgentIdentifier->IDTypeName . ':'
+            $id = (string)$agent->AgentIdentifier->IDTypeName . '_'
                 . (string)$agent->AgentIdentifier->IDValue;
-            if ($id != ':') {
+            if ($id != '_') {
                 $result['ids'][] = $id;
                 $result['idRoles'][]
                     = $this->formatAuthorIdWithRole($id, $relator);

--- a/src/RecordManager/Finna/Record/ForwardAuthority.php
+++ b/src/RecordManager/Finna/Record/ForwardAuthority.php
@@ -40,8 +40,6 @@ namespace RecordManager\Finna\Record;
  */
 class ForwardAuthority extends \RecordManager\Base\Record\ForwardAuthority
 {
-    use FinnaAuthorityRecordTrait;
-
     /**
      * Get occupations
      *


### PR DESCRIPTION
Instead of ':' use '_' to separate record type and id.