### PR TITLE
[ALLI-6520] MARC: index primary author id.

### DIFF
--- a/src/RecordManager/Base/Record/Marc.php
+++ b/src/RecordManager/Base/Record/Marc.php
@@ -400,6 +400,7 @@ class Marc extends Base
         $data['author2_id_str_mv'] = $this->getAuthorIds();
         $data['author2_id_role_str_mv']
             = array_merge(
+                $this->addNamespaceToAuthorityIds($primaryAuthors['idRoles']),
                 $this->addNamespaceToAuthorityIds($secondaryAuthors['idRoles']),
                 $this->addNamespaceToAuthorityIds($corporateAuthors['idRoles'])
             );
@@ -629,10 +630,12 @@ class Marc extends Base
      */
     public function getAuthorIds()
     {
+        $primaryAuthors = $this->getPrimaryAuthors();
         $secondaryAuthors = $this->getSecondaryAuthors();
         $corporateAuthors = $this->getCorporateAuthors();
 
         return array_merge(
+            $this->addNamespaceToAuthorityIds($primaryAuthors['ids']),
             $this->addNamespaceToAuthorityIds($secondaryAuthors['ids']),
             $this->addNamespaceToAuthorityIds($corporateAuthors['ids'])
         );


### PR DESCRIPTION
Päätekijän tunniste indeksoituu toisinaan `getSecondaryAuthors` in kautta, mutta ei aina (ilmeisesti liittyy e-kenttään):

https://kansalliskirjasto.finna.fi/Record/fikka.3378606#details
https://kansalliskirjasto.finna.fi/Record/fikka.3374670#details
