### PR TITLE
Clean up authority id support.

### DIFF
--- a/conf/datasources.ini.sample
+++ b/conf/datasources.ini.sample
@@ -39,19 +39,6 @@
 ;
 ; debugLog may be pointed to a file where all the OAI-PMH requests and responses are written.
 ;
-; To harvest MetaLib IRD's using MetaLib X-Server, create a section like this:
-;
-; [section_name]
-; type = metalib
-; url = http://metalib.adress/X
-; xUser = username
-; xPassword = password
-; format = marc
-; normalization = metalib_ird.properties
-; query = "WIN=INSTITUTE"
-; verbose = false
-; institution = MyInst
-;
 ; RecordManager settings:
 ; institution           The institution code mapped to the source (required)
 ; recordXPath           xpath expression used when loading records from a file to identify a single record (optional, e.g. //record)
@@ -86,7 +73,8 @@
 ;                       Use format fieldname:contents, e.g.
 ;                         extrafields[] = sector_str_mv:library
 ; driverParams[]        An array of extra parameters that can be used to customize record driver behavior
-; enrichments[]         An array of enrichment class names that can be used to enrich records
+; enrichments[]         An array of enrichment class names that can be used to enrich records. ",final" can be appended to indicate that enrichment is executed to the
+;                       final record after mappings etc. have been processed. By default it is executed before mappings, normalization etc.
 ; componentPartSourceId[] An array defining linked sources that are used to fetch component parts from this source
 ; authority[<type>]     Map to authority index sources where <type> is authority record type
 ;                       (corporateBody, person) or * for any;
@@ -129,6 +117,19 @@ componentParts = merge_non_articles
 dedup = true
 building_mapping = voyager_locations.map
 
+; Sample Koha configuration
+[koha]
+url = https://koha.address/cgi-bin/koha/opac/oai.pl
+metadataPrefix = marc21
+institution = SampleInstitution
+format = marc
+componentParts = merge_non_earticles
+dedup = true
+driverParams[] = "idIn999=true"
+driverParams[] = "003InLinkingID=true"
+driverParams[] = "kohaNormalization=true"
+enrichments[] = MarcAuthEnrichment,final
+
 ; Sample DSpace configuration
 [dspace]
 url = http://dspace.server/dspace-oai/request
@@ -153,15 +154,6 @@ prepend_title_with_subtitle = true
 prepend_parent_title_with_unitid = true
 recordXPath = //ead
 oaiIDXPath = ../../header/identifier
-
-; Sample MetaLib CKB Export configuration
-[metalib]
-type = metalib_export
-format = marc
-url = https://www.nelliportaali.fi/finna_export/
-filePrefix = "METALIB_"
-fileSuffix = ".xml"
-preTransformation = metalib_export.xsl
 
 ; Sample SFX configuration
 [sfx]

--- a/src/RecordManager/Base/Enrichment/AuthEnrichment.php
+++ b/src/RecordManager/Base/Enrichment/AuthEnrichment.php
@@ -103,17 +103,11 @@ abstract class AuthEnrichment extends Enrichment
     protected function enrichField($sourceId, $record, &$solrArray,
         $id, $solrField, $includeInAllfields = false
     ) {
-        $recAuthSource = $record->getAuthorityNamespace();
-
-        if (!($data = $this->authorityDb->getRecord($recAuthSource . '.' . $id))) {
+        if (!($data = $this->authorityDb->getRecord($id))) {
             return;
         }
 
         $source = $data['source_id'];
-
-        if ($source !== $recAuthSource) {
-            return;
-        }
 
         $authRecord = $this->recordFactory->createRecord(
             $data['format'],

--- a/src/RecordManager/Base/Enrichment/MarcAuthEnrichment.php
+++ b/src/RecordManager/Base/Enrichment/MarcAuthEnrichment.php
@@ -54,10 +54,8 @@ class MarcAuthEnrichment extends AuthEnrichment
             return;
         }
 
-        $datasourceSettings = $record->getDataSourceSettings();
-
         foreach ($record->getAuthorIds() as $id) {
-            list($source, $id) = explode('.', $id, 2);
+            list(, $id) = explode('.', $id, 2);
             $this->enrichField(
                 $sourceId, $record, $solrArray, $id, 'author_variant', true
             );

--- a/src/RecordManager/Base/Enrichment/MarcAuthEnrichment.php
+++ b/src/RecordManager/Base/Enrichment/MarcAuthEnrichment.php
@@ -55,7 +55,6 @@ class MarcAuthEnrichment extends AuthEnrichment
         }
 
         foreach ($record->getAuthorIds() as $id) {
-            list(, $id) = explode('.', $id, 2);
             $this->enrichField(
                 $sourceId, $record, $solrArray, $id, 'author_variant', true
             );

--- a/src/RecordManager/Base/Enrichment/MarcAuthEnrichment.php
+++ b/src/RecordManager/Base/Enrichment/MarcAuthEnrichment.php
@@ -54,7 +54,7 @@ class MarcAuthEnrichment extends AuthEnrichment
             return;
         }
 
-        foreach ($solrArray['author2_ids_str_mv'] ?? [] as $id) {
+        foreach ($solrArray['author2_id_str_mv'] ?? [] as $id) {
             $this->enrichField(
                 $sourceId, $record, $solrArray, $id, 'author_variant', true
             );

--- a/src/RecordManager/Base/Enrichment/MarcAuthEnrichment.php
+++ b/src/RecordManager/Base/Enrichment/MarcAuthEnrichment.php
@@ -54,7 +54,7 @@ class MarcAuthEnrichment extends AuthEnrichment
             return;
         }
 
-        foreach ($record->getAuthorIds() as $id) {
+        foreach ($solrArray['author2_ids_str_mv'] ?? [] as $id) {
             $this->enrichField(
                 $sourceId, $record, $solrArray, $id, 'author_variant', true
             );

--- a/src/RecordManager/Base/Record/Marc.php
+++ b/src/RecordManager/Base/Record/Marc.php
@@ -45,8 +45,6 @@ use RecordManager\Base\Utils\MetadataUtils;
  */
 class Marc extends Base
 {
-    use AuthoritySupportTrait;
-
     const SUBFIELD_INDICATOR = "\x1F";
     const END_OF_FIELD = "\x1E";
     const END_OF_RECORD = "\x1D";
@@ -409,15 +407,6 @@ class Marc extends Base
         $corporateAuthors = $this->getCorporateAuthors();
         $data['author_corporate'] = $corporateAuthors['names'];
         $data['author_corporate_role'] = $corporateAuthors['relators'];
-
-        $data['author2_id_str_mv'] = $this->getAuthorIds();
-        $data['author2_id_role_str_mv']
-            = array_merge(
-                $this->addNamespaceToAuthorityIds($primaryAuthors['idRoles']),
-                $this->addNamespaceToAuthorityIds($secondaryAuthors['idRoles']),
-                $this->addNamespaceToAuthorityIds($corporateAuthors['idRoles'])
-            );
-
         $data['author_additional'] = $this->getFieldsSubfields(
             [
                 [self::GET_BOTH, '505', ['r' => 1]]
@@ -663,15 +652,7 @@ class Marc extends Base
      */
     public function getAuthorIds()
     {
-        $primaryAuthors = $this->getPrimaryAuthors();
-        $secondaryAuthors = $this->getSecondaryAuthors();
-        $corporateAuthors = $this->getCorporateAuthors();
-
-        return array_merge(
-            $this->addNamespaceToAuthorityIds($primaryAuthors['ids']),
-            $this->addNamespaceToAuthorityIds($secondaryAuthors['ids']),
-            $this->addNamespaceToAuthorityIds($corporateAuthors['ids'])
-        );
+        return [];
     }
 
     /**
@@ -2218,7 +2199,7 @@ class Marc extends Base
     protected function getAllFields()
     {
         $subfieldFilter = [
-            '650' => ['2' => 1, '6' => 1, '8' => 1],
+            '650' => ['0' => 1, '2' => 1, '6' => 1, '8' => 1],
             '773' => ['6' => 1, '7' => 1, '8' => 1, 'w' => 1],
             '856' => ['6' => 1, '8' => 1, 'q' => 1]
         ];
@@ -2228,7 +2209,7 @@ class Marc extends Base
                 foreach ($fields as $field) {
                     $subfields = $this->getAllSubfields(
                         $field,
-                        $subfieldFilter[$tag] ?? ['6' => 1, '8' => 1]
+                        $subfieldFilter[$tag] ?? ['0' => 1, '6' => 1, '8' => 1]
                     );
                     if ($subfields) {
                         $allFields = array_merge($allFields, $subfields);

--- a/src/RecordManager/Base/Record/Marc.php
+++ b/src/RecordManager/Base/Record/Marc.php
@@ -2944,4 +2944,17 @@ class Marc extends Base
 
         return $result;
     }
+
+    /**
+     * Combine author id and role into a string that can be indexed.
+     *
+     * @param string $id   Id
+     * @param string $role Role
+     *
+     * @return string
+     */
+    protected function formatAuthorIdWithRole($id, $role)
+    {
+        return '';
+    }
 }

--- a/src/RecordManager/Base/Record/Marc.php
+++ b/src/RecordManager/Base/Record/Marc.php
@@ -646,16 +646,6 @@ class Marc extends Base
     }
 
     /**
-     * Return author ids that are indexed to author2_id_str_mv
-     *
-     * @return array
-     */
-    public function getAuthorIds()
-    {
-        return [];
-    }
-
-    /**
      * Return record ID (local)
      *
      * @return string

--- a/src/RecordManager/Base/Solr/SolrUpdater.php
+++ b/src/RecordManager/Base/Solr/SolrUpdater.php
@@ -2972,7 +2972,7 @@ class SolrUpdater
      * @param array  $data     Array of Solr fields
      * @param string $stage    Stage of record processing
      *                         - empty is for default, i.e. right after record has
-     *                           been converted to a Solr array but not mapped
+     *                         been converted to a Solr array but not mapped
      *                         - "final" is for final Solr array after mappings etc.
      *
      * @return void

--- a/src/RecordManager/Base/Solr/SolrUpdater.php
+++ b/src/RecordManager/Base/Solr/SolrUpdater.php
@@ -1721,7 +1721,7 @@ class SolrUpdater
                         ->transformToSolrArray($metadataRecord->toXML(), $params);
                 } else {
                     $data = $metadataRecord->toSolrArray($this->db);
-                    $this->enrich($source, $settings, $metadataRecord, $data);
+                    $this->enrich($source, $settings, $metadataRecord, $data, '');
                 }
             }
             if (isset($data[$field])) {
@@ -2026,7 +2026,7 @@ class SolrUpdater
                 ->transformToSolrArray($metadataRecord->toXML(), $params);
         } else {
             $data = $metadataRecord->toSolrArray($this->db);
-            $this->enrich($source, $settings, $metadataRecord, $data);
+            $this->enrich($source, $settings, $metadataRecord, $data, '');
         }
 
         $data['id'] = $this->createSolrId($record['_id']);
@@ -2323,6 +2323,8 @@ class SolrUpdater
                 $data[$this->warningsField] = $warnings;
             }
         }
+
+        $this->enrich($source, $settings, $metadataRecord, $data, 'final');
 
         return $data;
     }
@@ -2968,10 +2970,14 @@ class SolrUpdater
      * @param array  $settings Data source settings
      * @param object $record   Metadata record
      * @param array  $data     Array of Solr fields
+     * @param string $stage    Stage of record processing
+     *                         - empty is for default, i.e. right after record has
+     *                           been converted to a Solr array but not mapped
+     *                         - "final" is for final Solr array after mappings etc.
      *
      * @return void
      */
-    protected function enrich($source, $settings, $record, &$data)
+    protected function enrich($source, $settings, $record, &$data, $stage = '')
     {
         $enrichments = array_unique(
             array_merge(
@@ -2979,7 +2985,13 @@ class SolrUpdater
                 (array)($settings['enrichments'] ?? [])
             )
         );
-        foreach ($enrichments as $enrichment) {
+        foreach ($enrichments as $enrichmentSettings) {
+            $parts = explode(',', $enrichmentSettings);
+            $enrichment = $parts[0];
+            $enrichmentStage = $parts[1] ?? '';
+            if ($stage !== $enrichmentStage) {
+                continue;
+            }
             if (!isset($this->enrichments[$enrichment])) {
                 $className = $enrichment;
                 if (strpos($className, '\\') === false) {

--- a/src/RecordManager/Finna/Record/AuthoritySupportTrait.php
+++ b/src/RecordManager/Finna/Record/AuthoritySupportTrait.php
@@ -45,7 +45,7 @@ trait AuthoritySupportTrait
      *
      * @return string
      */
-    public function getAuthorityNamespace($type = '*')
+    protected function getAuthorityNamespace($type = '*')
     {
         return $this->dataSourceSettings[$this->source]['authority'][$type] ?? '';
     }

--- a/src/RecordManager/Finna/Record/Forward.php
+++ b/src/RecordManager/Finna/Record/Forward.php
@@ -28,7 +28,6 @@
  */
 namespace RecordManager\Finna\Record;
 
-use RecordManager\Base\Record\AuthoritySupportTrait;
 use RecordManager\Base\Utils\MetadataUtils;
 
 /**

--- a/src/RecordManager/Finna/Record/Marc.php
+++ b/src/RecordManager/Finna/Record/Marc.php
@@ -694,33 +694,6 @@ class Marc extends \RecordManager\Base\Record\Marc
     }
 
     /**
-     * Return author ids that are indexed to author2_id_str_mv
-     *
-     * @return array
-     */
-    public function getAuthorIds()
-    {
-        $primaryAuthors = $this->getPrimaryAuthors();
-        $secondaryAuthors = $this->getSecondaryAuthors();
-        $corporateAuthors = $this->getCorporateAuthors();
-
-        // TODO: Do we really need this?
-        $additional = [];
-        foreach ($this->getFields('700') as $field) {
-            if ($id = $this->getSubField($field, '0')) {
-                $additional[] = $id;
-            }
-        }
-
-        return array_merge(
-            $primaryAuthors['ids'],
-            $secondaryAuthors['ids'],
-            $corporateAuthors['ids'],
-            $additional
-        );
-    }
-
-    /**
      * Get all non-specific topics
      *
      * @return array

--- a/src/RecordManager/Finna/Record/Marc.php
+++ b/src/RecordManager/Finna/Record/Marc.php
@@ -44,6 +44,8 @@ use RecordManager\Base\Utils\MetadataUtils;
  */
 class Marc extends \RecordManager\Base\Record\Marc
 {
+    use AuthoritySupportTrait;
+
     /**
      * Strings in field 300 that signify that the work is illustrated.
      *
@@ -144,6 +146,20 @@ class Marc extends \RecordManager\Base\Record\Marc
                 }
             }
         }
+
+        $primaryAuthors = $this->getPrimaryAuthors();
+        $secondaryAuthors = $this->getSecondaryAuthors();
+        $corporateAuthors = $this->getCorporateAuthors();
+        $data['author2_id_str_mv'] = array_merge(
+            $this->addNamespaceToAuthorityIds($primaryAuthors['ids']),
+            $this->addNamespaceToAuthorityIds($secondaryAuthors['ids']),
+            $this->addNamespaceToAuthorityIds($corporateAuthors['ids'])
+        );
+        $data['author2_id_role_str_mv'] = array_merge(
+            $this->addNamespaceToAuthorityIds($primaryAuthors['idRoles']),
+            $this->addNamespaceToAuthorityIds($secondaryAuthors['idRoles']),
+            $this->addNamespaceToAuthorityIds($corporateAuthors['idRoles'])
+        );
 
         if (isset($data['publishDate'])) {
             $data['main_date_str']
@@ -667,12 +683,7 @@ class Marc extends \RecordManager\Base\Record\Marc
         }
 
         // Additional authority ids
-        foreach ($this->getFields('600') as $field) {
-            if ($id = $this->getSubField($field, '0')) {
-                $data['topic_id_str_mv']
-                    = $this->addNamespaceToAuthorityIds([$id]);
-            }
-        }
+        $data['topic_id_str_mv'] = $this->getTopicIds();
 
         // Make sure center_coords is single-valued
         if (!empty($data['center_coords'])) {
@@ -689,14 +700,43 @@ class Marc extends \RecordManager\Base\Record\Marc
      */
     public function getAuthorIds()
     {
-        $ids = parent::getAuthorIds();
+        $primaryAuthors = $this->getPrimaryAuthors();
+        $secondaryAuthors = $this->getSecondaryAuthors();
+        $corporateAuthors = $this->getCorporateAuthors();
 
+        // TODO: Do we really need this?
+        $additional = [];
         foreach ($this->getFields('700') as $field) {
             if ($id = $this->getSubField($field, '0')) {
-                $ids = array_merge($ids, $this->addNamespaceToAuthorityIds([$id]));
+                $additional[] = $id;
             }
         }
-        return $ids;
+
+        return array_merge(
+            $this->addNamespaceToAuthorityIds($primaryAuthors['ids']),
+            $this->addNamespaceToAuthorityIds($secondaryAuthors['ids']),
+            $this->addNamespaceToAuthorityIds($corporateAuthors['ids']),
+            $this->addNamespaceToAuthorityIds($additional)
+        );
+    }
+
+    /**
+     * Get all non-specific topics
+     *
+     * @return array
+     */
+    protected function getTopicIds()
+    {
+        $fieldTags = ['600', '610', '611', '630', '650'];
+        $result = [];
+        foreach ($fieldTags as $tag) {
+            foreach ($this->getFields($tag) as $field) {
+                if ($id = $this->getSubfield($field, '0')) {
+                    $result[] = $id;
+                }
+            }
+        }
+        return $this->addNamespaceToAuthorityIds($result);
     }
 
     /**
@@ -742,10 +782,22 @@ class Marc extends \RecordManager\Base\Record\Marc
                     [self::GET_NORMAL, '110', ['a' => 1, 'e' => 1]]
                 ]
             );
+            $authorIds = $marc->getFieldsSubfields(
+                [
+                    [self::GET_NORMAL, '100', ['0' => 1]],
+                    [self::GET_NORMAL, '110', ['0' => 1]]
+                ]
+            );
             $additionalAuthors = $marc->getFieldsSubfields(
                 [
                     [self::GET_NORMAL, '700', ['a' => 1, 'e' => 1]],
                     [self::GET_NORMAL, '710', ['a' => 1, 'e' => 1]]
+                ]
+            );
+            $additionalAuthorIds = $marc->getFieldsSubfields(
+                [
+                    [self::GET_NORMAL, '700', ['0' => 1]],
+                    [self::GET_NORMAL, '710', ['0' => 1]]
                 ]
             );
             $duration = $marc->getFieldsSubfields(
@@ -1221,10 +1273,10 @@ class Marc extends \RecordManager\Base\Record\Marc
                 'y' => 1, 'z' => 1, '2' => 1, '6' => 1, '8' => 1
             ],
             '650' => ['0' => 1, '2' => 1, '6' => 1, '8' => 1],
-            '100' => ['4' => 1],
-            '700' => ['4' => 1],
-            '710' => ['4' => 1],
-            '711' => ['4' => 1],
+            '100' => ['0' => 1, '4' => 1],
+            '700' => ['0' => 1, '4' => 1],
+            '710' => ['0' => 1, '4' => 1],
+            '711' => ['0' => 1, '4' => 1],
             '773' => [
                 '0' => 1, '4' => 1, '6' => 1, '7' => 1, '8' => 1, 'g' => 1, 'q' => 1,
                 'w' => 1

--- a/src/RecordManager/Finna/Record/Marc.php
+++ b/src/RecordManager/Finna/Record/Marc.php
@@ -713,10 +713,10 @@ class Marc extends \RecordManager\Base\Record\Marc
         }
 
         return array_merge(
-            $this->addNamespaceToAuthorityIds($primaryAuthors['ids']),
-            $this->addNamespaceToAuthorityIds($secondaryAuthors['ids']),
-            $this->addNamespaceToAuthorityIds($corporateAuthors['ids']),
-            $this->addNamespaceToAuthorityIds($additional)
+            $primaryAuthors['ids'],
+            $secondaryAuthors['ids'],
+            $corporateAuthors['ids'],
+            $additional
         );
     }
 

--- a/tests/RecordManager/Test/RecordDrivers/FinnaMarcRecordDriverTest.php
+++ b/tests/RecordManager/Test/RecordDrivers/FinnaMarcRecordDriverTest.php
@@ -47,7 +47,17 @@ class FinnaMarcRecordDriverTest extends RecordDriverTest
      */
     public function testMarc1()
     {
-        $record = $this->createRecord(Marc::class, 'marc1.xml');
+        $record = $this->createRecord(
+            Marc::class,
+            'marc1.xml',
+            [
+                '__unit_test_no_source__' => [
+                    'authority' => [
+                        '*' => 'testauth'
+                    ],
+                ]
+            ]
+        );
         $fields = $record->toSolrArray();
         unset($fields['fullrecord']);
 
@@ -223,6 +233,13 @@ class FinnaMarcRecordDriverTest extends RecordDriverTest
                 'Sajavaara, Paula',
             ],
             'format_ext_str_mv' => 'Book',
+            'author2_id_str_mv' => [
+                'testauth.(TEST)1',
+                'testauth.(TEST)1',
+                'testauth.(TEST)2',
+                'testauth.(TEST)3',
+            ],
+            'topic_id_str_mv' => [],
         ];
 
         $this->compareArray($expected, $fields, 'toSolrArray');
@@ -426,6 +443,12 @@ class FinnaMarcRecordDriverTest extends RecordDriverTest
                 'Kalat, James W.',
             ],
             'format_ext_str_mv' => 'Book',
+            'topic_id_str_mv' => [
+                'http://www.yso.fi/onto/yso/p14664',
+                'test\\\\\\.12',
+                'BIOTEST\\.12',
+                '(BIOTEST)1234',
+            ],
         ];
 
         $this->compareArray($expected, $fields, 'toSolrArray');
@@ -620,6 +643,7 @@ class FinnaMarcRecordDriverTest extends RecordDriverTest
                 'Maanmittaushallitus',
             ],
             'format_ext_str_mv' => 'Map',
+            'topic_id_str_mv' => [],
         ];
 
         $this->compareArray($expected, $fields, 'toSolrArray');
@@ -751,6 +775,9 @@ class FinnaMarcRecordDriverTest extends RecordDriverTest
                 'Author, Test',
             ],
             'format_ext_str_mv' => 'BachelorsThesisPolytechnic',
+            'topic_id_str_mv' => [
+                'http://www.yso.fi/onto/yso/p8471',
+            ],
         ];
 
         $this->compareArray($expected, $fields, 'toSolrArray');
@@ -877,6 +904,9 @@ class FinnaMarcRecordDriverTest extends RecordDriverTest
                 'Author, Test',
             ],
             'format_ext_str_mv' => 'BachelorsThesisPolytechnic',
+            'topic_id_str_mv' => [
+                'http://www.yso.fi/onto/yso/p8471',
+            ],
         ];
 
         $this->compareArray($expected, $fields, 'toSolrArray');

--- a/tests/RecordManager/Test/RecordDrivers/MarcRecordDriverTest.php
+++ b/tests/RecordManager/Test/RecordDrivers/MarcRecordDriverTest.php
@@ -124,8 +124,6 @@ class MarcRecordDriverTest extends RecordDriverTest
             ],
             'author_corporate_role' => [
             ],
-            'author2_id_str_mv' => [],
-            'author2_id_role_str_mv' => [],
             'author_additional' => [
             ],
             'title' => 'Tutki ja kirjoita',
@@ -282,9 +280,7 @@ class MarcRecordDriverTest extends RecordDriverTest
                 '&käytt&tdk',
                 '&vanha&painos',
                 'neuropsykologia',
-                'http://www.yso.fi/onto/yso/p14664',
                 'biopsykologia',
-                'http://www.yso.fi/onto/yso/p9372',
                 'neuropsykologi',
                 'biopsykologi',
             ],
@@ -314,8 +310,6 @@ class MarcRecordDriverTest extends RecordDriverTest
             ],
             'author_corporate_role' => [
             ],
-            'author2_id_str_mv' => [],
-            'author2_id_role_str_mv' => [],
             'author_additional' => [
             ],
             'title' => 'Biological psychology',
@@ -496,10 +490,6 @@ class MarcRecordDriverTest extends RecordDriverTest
             'author_corporate_role' => [
                 '-',
             ],
-            'author2_id_str_mv' => [
-            ],
-            'author2_id_role_str_mv' => [
-            ],
             'author_additional' => [
             ],
             'title' => 'Suomen tiekartta = Vägkarta över Finland. 1.',
@@ -662,10 +652,6 @@ class MarcRecordDriverTest extends RecordDriverTest
             'author_corporate' => [
             ],
             'author_corporate_role' => [
-            ],
-            'author2_id_str_mv' => [
-            ],
-            'author2_id_role_str_mv' => [
             ],
             'author_additional' => [
             ],

--- a/tests/RecordManager/Test/RecordDrivers/RecordDriverTest.php
+++ b/tests/RecordManager/Test/RecordDrivers/RecordDriverTest.php
@@ -75,11 +75,15 @@ abstract class RecordDriverTest extends \RecordManager\Test\AbstractTest
     {
         foreach ($expected as $key => $value) {
             $this->assertEquals(
-                $value, $provided[$key] ?? null, "[$method] Compare field $key"
+                $value,
+                $provided[$key] ?? null,
+                "[$method] Compare expected field $key"
             );
         }
-        $this->assertEquals(
-            count($expected), count($provided), "[$method] Field count equal"
-        );
+        foreach ($provided as $key => $value) {
+            $this->assertTrue(array_key_exists($key, $expected) !== false,
+                "[$method] Unexpected field $key: " . var_export($value, true)
+            );
+        }
     }
 }

--- a/tests/samples/marc1.xml
+++ b/tests/samples/marc1.xml
@@ -34,6 +34,7 @@
   </datafield>
   <datafield tag="100" ind1="1" ind2=" ">
     <subfield code="a">Hirsjärvi, Sirkka.</subfield>
+    <subfield code="0">(TEST)1</subfield>
   </datafield>
   <datafield tag="245" ind1="1" ind2="0">
     <subfield code="a">Tutki ja kirjoita /</subfield>
@@ -107,9 +108,11 @@
   </datafield>
   <datafield tag="700" ind1="1" ind2=" ">
     <subfield code="a">Remes, Pirkko.</subfield>
+    <subfield code="0">(TEST)2</subfield>
   </datafield>
   <datafield tag="700" ind1="1" ind2=" ">
     <subfield code="a">Sajavaara, Paula.</subfield>
+    <subfield code="0">(TEST)3</subfield>
   </datafield>
   <datafield tag="852" ind1="8" ind2=" ">
     <subfield code="a">E</subfield>

--- a/tests/samples/marc2.xml
+++ b/tests/samples/marc2.xml
@@ -71,18 +71,18 @@
   </datafield>
   <datafield tag="650" ind1=" " ind2="7">
     <subfield code="a">biopsykologia</subfield>
-    <subfield code="2">yso/fin</subfield>
-    <subfield code="0">http://www.yso.fi/onto/yso/p9372</subfield>
+    <subfield code="2">test</subfield>
+    <subfield code="0">test\.12</subfield>
   </datafield>
   <datafield tag="650" ind1=" " ind2="7">
     <subfield code="a">neuropsykologi</subfield>
-    <subfield code="2">yso/swe</subfield>
-    <subfield code="0">http://www.yso.fi/onto/yso/p14664</subfield>
+    <subfield code="2">biotest</subfield>
+    <subfield code="0">BIOTEST.12</subfield>
   </datafield>
   <datafield tag="650" ind1=" " ind2="7">
     <subfield code="a">biopsykologi</subfield>
-    <subfield code="2">yso/swe</subfield>
-    <subfield code="0">http://www.yso.fi/onto/yso/p9372</subfield>
+    <subfield code="2">biotest</subfield>
+    <subfield code="0">(BIOTEST)1234</subfield>
   </datafield>
   <datafield tag="850" ind1=" " ind2=" ">
     <subfield code="a">FI-Hc</subfield>


### PR DESCRIPTION
- Only in Finna classes.
- Add prefixes to non-http identifiers only.
- Don't add any prefix if no prefix is defined.
- Escape period and backslash.
- Add possibility to indicate when to run an enrichment.