### PR TITLE
[ALLI-6551] EAD3: handle multiple date ranges

### DIFF
--- a/src/RecordManager/Finna/Record/Ead3.php
+++ b/src/RecordManager/Finna/Record/Ead3.php
@@ -452,8 +452,16 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
             if (isset($date->daterange)) {
                 $range = $this->doc->did->unitdatestructured->daterange;
                 if (isset($range->fromdate) && isset($range->todate)) {
+                    $fromDates = $this->doc->did->unitdatestructured->daterange
+                        ->xpath('fromdate');
+                    $toDates = $this->doc->did->unitdatestructured->daterange
+                        ->xpath('todate');
+
+                    $from = reset($fromDates);
+                    $to = end($toDates);
+
                     return $this->parseDateRange(
-                        (string)$range->fromdate . '/' . (string)$range->todate
+                        (string)$from . '/' . (string)$to
                     );
                 }
             } elseif (isset($date->datesingle)) {

--- a/src/RecordManager/Finna/Record/Ead3.php
+++ b/src/RecordManager/Finna/Record/Ead3.php
@@ -452,10 +452,8 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
             if (isset($date->daterange)) {
                 $range = $this->doc->did->unitdatestructured->daterange;
                 if (isset($range->fromdate) && isset($range->todate)) {
-                    $fromDates = $this->doc->did->unitdatestructured->daterange
-                        ->xpath('fromdate');
-                    $toDates = $this->doc->did->unitdatestructured->daterange
-                        ->xpath('todate');
+                    $fromDates = $range->xpath('fromdate');
+                    $toDates = $range->xpath('todate');
 
                     $from = reset($fromDates);
                     $to = end($toDates);

--- a/tests/RecordManager/Test/RecordDrivers/Ead3RecordDriverTest.php
+++ b/tests/RecordManager/Test/RecordDrivers/Ead3RecordDriverTest.php
@@ -214,7 +214,6 @@ class Ead3RecordDriverTest extends RecordDriverTest
      */
     public function testFsd2()
     {
-        // uu5u-11-05/u960-01-01
         $fields = $this->createRecord(Ead3::class, 'fsd2.xml')->toSolrArray();
         $this->assertContains(
             '[2017-01-20 TO 2018-04-30]',

--- a/tests/RecordManager/Test/RecordDrivers/Ead3RecordDriverTest.php
+++ b/tests/RecordManager/Test/RecordDrivers/Ead3RecordDriverTest.php
@@ -206,4 +206,19 @@ class Ead3RecordDriverTest extends RecordDriverTest
             $fields['search_daterange_mv']
         );
     }
+
+    /**
+     * Test FSD EAD3 record handling.
+     *
+     * @return void
+     */
+    public function testFsd2()
+    {
+        // uu5u-11-05/u960-01-01
+        $fields = $this->createRecord(Ead3::class, 'fsd2.xml')->toSolrArray();
+        $this->assertContains(
+            '[2017-01-20 TO 2018-04-30]',
+            $fields['search_daterange_mv']
+        );
+    }
 }

--- a/tests/samples/fsd2.xml
+++ b/tests/samples/fsd2.xml
@@ -1,0 +1,41 @@
+<record>
+  <control>
+    <recordid>123</recordid>
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="3.1.2" lang="fin"></titleproper>
+        <author></author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher></publisher>
+      </publicationstmt>
+    </filedesc>
+    <maintenancestatus value="derived"/>
+    <maintenanceagency>
+      <agencycode lang="eng"></agencycode>
+    </maintenanceagency>
+    <maintenancehistory>
+      <maintenanceevent>
+        <eventtype value=""/>
+        <eventdatetime/>
+        <agenttype value=""/>
+        <agent/>
+      </maintenanceevent>
+    </maintenancehistory>
+  </control>
+  <did>
+    <unitid />
+    <unitdatestructured datechar="collection">
+      <daterange lang="fi">
+        <fromdate lang="fi" standarddate="2017-01-20">2017-01-20</fromdate>
+        <todate lang="fi" standarddate="2017-04-06">2017-04-06</todate>
+        <fromdate lang="fi" standarddate="2017-10">2017-10</fromdate>
+        <todate lang="fi" standarddate="2017-12">2017-12</todate>
+        <fromdate lang="fi" standarddate="2017-08-23">2017-08-23</fromdate>
+        <todate lang="fi" standarddate="2017-10-13">2017-10-13</todate>
+        <fromdate lang="fi" standarddate="2018-03">2018-03</fromdate>
+        <todate lang="fi" standarddate="2018-04">2018-04</todate>
+      </daterange>
+    </unitdatestructured>
+  </did>
+</record>


### PR DESCRIPTION
Nykyinen versio ei käsittele useampia `did->unitdatestructured->daterange` elementtejä.

Toteutus olettaa että jaksot ovat aikajärjestyksessä.