### PR TITLE
[ALLI-5847] [ALLI-6865] EAD3: improve daterange parsing

### DIFF
--- a/src/RecordManager/Finna/Record/Ead3.php
+++ b/src/RecordManager/Finna/Record/Ead3.php
@@ -94,7 +94,8 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
             $data['search_daterange_mv'][] = $data['unit_daterange']
                 = MetadataUtils::dateRangeToStr($unitDateRange);
 
-            $data['main_date_str'] = MetadataUtils::extractYear($unitDateRange[0]);
+            $data['main_date_str'] = $data['era_facet']
+                = MetadataUtils::extractYear($unitDateRange[0]);
             $data['main_date'] = $this->validateDate($unitDateRange[0]);
 
             if (!$startDateUnknown) {
@@ -489,9 +490,11 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
             if (!empty($normal)) {
                 return $this->parseDateRange($normal);
             } else {
-                return $this->parseDateRange(
-                    str_replace('-', '/', (string)$unitdate)
-                );
+                $date = str_replace('-', '/', (string)$unitdate);
+                if (false === strpos($date, '/')) {
+                    $date = "${date}/${date}";
+                }
+                return $this->parseDateRange($date);
             }
         }
         return null;

--- a/src/RecordManager/Finna/Record/Ead3.php
+++ b/src/RecordManager/Finna/Record/Ead3.php
@@ -476,11 +476,22 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
                 if ($attributes->label
                     && (string)$attributes->label === 'Ajallinen kattavuus'
                 ) {
-                    return $this->parseDateRange(
+                    $date = $this->parseDateRange(
                         (string)$unitdate->attributes()->normal
                     );
-                    break;
+                    if (!$date['startDateUnknown'] && !$date['endDateUnknown']) {
+                        return $date;
+                    }
                 }
+            }
+            $unitdate = $this->doc->did->unitdate;
+            $normal = (string)$unitdate->attributes()->normal;
+            if (!empty($normal)) {
+                return $this->parseDateRange($normal);
+            } else {
+                return $this->parseDateRange(
+                    str_replace('-', '/', (string)$unitdate)
+                );
             }
         }
         return null;
@@ -498,8 +509,6 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
         if (!$input || $input == '-' || false === strpos($input, '/')) {
             return null;
         }
-
-        $yearLimits = ['0000', '9999'];
 
         list($start, $end) = explode('/', $input);
 
@@ -574,6 +583,7 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
         }
 
         $startDateUnknown = $startDate['unknown'];
+        $endDateUnknown = $endDate['unknown'];
 
         $startDate = $startDate['date'];
         $endDate = $endDate['date'];
@@ -590,7 +600,8 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
 
         return [
             'date' => [$startDate, $endDate],
-            'startDateUnknown' => $startDateUnknown
+            'startDateUnknown' => $startDateUnknown,
+            'endDateUnknown' => $endDateUnknown,
         ];
     }
 

--- a/tests/RecordManagerTest/Finna/Record/Ead3Test.php
+++ b/tests/RecordManagerTest/Finna/Record/Ead3Test.php
@@ -252,4 +252,19 @@ class Ead3RecordDriverTest extends \RecordManagerTest\Base\Record\RecordTest
         );
     }
 
+    /**
+     * Test YKSA EAD3 record handling
+     *
+     * @return void
+     */
+    public function testYksa2()
+    {
+        // <unitdate>1931</unitdate>
+        $fields = $this->createRecord(Ead3::class, 'yksa2.xml', [], 'finna')->toSolrArray();
+        $this->assertContains(
+            '[1931-01-01 TO 1931-12-31]',
+            $fields['search_daterange_mv']
+        );
+    }
+
 }

--- a/tests/RecordManagerTest/Finna/Record/Ead3Test.php
+++ b/tests/RecordManagerTest/Finna/Record/Ead3Test.php
@@ -193,6 +193,36 @@ class Ead3RecordDriverTest extends \RecordManagerTest\Base\Record\RecordTest
     }
 
     /**
+     * Test AHAA EAD3 record handling
+     *
+     * @return void
+     */
+    public function testAhaa12()
+    {
+        // Prefer unitdate with label "Ajallinen kattavuus"
+        $fields = $this->createRecord(Ead3::class, 'ahaa12.xml', [], 'finna')->toSolrArray();
+        $this->assertContains(
+            '[1970-01-01 TO 1971-12-31]',
+            $fields['search_daterange_mv']
+        );
+    }
+
+    /**
+     * Test AHAA EAD3 record handling
+     *
+     * @return void
+     */
+    public function testAhaa13()
+    {
+        // Discard unitdate with label "Ajallinen kattavuus" when starttime or endtime is unknown
+        $fields = $this->createRecord(Ead3::class, 'ahaa13.xml', [], 'finna')->toSolrArray();
+        $this->assertContains(
+            '[1992-01-01 TO 1993-12-31]',
+            $fields['search_daterange_mv']
+        );
+    }
+
+    /**
      * Test FSD EAD3 record handling
      *
      * @return void
@@ -206,4 +236,20 @@ class Ead3RecordDriverTest extends \RecordManagerTest\Base\Record\RecordTest
             $fields['search_daterange_mv']
         );
     }
+
+    /**
+     * Test YKSA EAD3 record handling
+     *
+     * @return void
+     */
+    public function testYksa()
+    {
+        // <unitdate>1918-1931</unitdate>
+        $fields = $this->createRecord(Ead3::class, 'yksa.xml', [], 'finna')->toSolrArray();
+        $this->assertContains(
+            '[1918-01-01 TO 1931-12-31]',
+            $fields['search_daterange_mv']
+        );
+    }
+
 }

--- a/tests/RecordManagerTest/Finna/Record/Ead3Test.php
+++ b/tests/RecordManagerTest/Finna/Record/Ead3Test.php
@@ -266,5 +266,4 @@ class Ead3RecordDriverTest extends \RecordManagerTest\Base\Record\RecordTest
             $fields['search_daterange_mv']
         );
     }
-
 }

--- a/tests/RecordManagerTest/Finna/Record/Ead3Test.php
+++ b/tests/RecordManagerTest/Finna/Record/Ead3Test.php
@@ -25,7 +25,7 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://github.com/NatLibFi/RecordManager
  */
-namespace RecordManagerTest\Base\Record;
+namespace RecordManagerTest\Finna\Record;
 
 use RecordManager\Finna\Record\Ead3;
 

--- a/tests/fixtures/finna/record/ahaa12.xml
+++ b/tests/fixtures/finna/record/ahaa12.xml
@@ -1,0 +1,31 @@
+<record>
+  <control>
+    <recordid>123</recordid>
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="3.1.2" lang="fin"></titleproper>
+        <author></author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher></publisher>
+      </publicationstmt>
+    </filedesc>
+    <maintenancestatus value="derived"/>
+    <maintenanceagency>
+      <agencycode lang="eng"></agencycode>
+    </maintenanceagency>
+    <maintenancehistory>
+      <maintenanceevent>
+        <eventtype value=""/>
+        <eventdatetime/>
+        <agenttype value=""/>
+        <agent/>
+      </maintenanceevent>
+    </maintenancehistory>
+  </control>
+  <did>
+    <unitid />
+    <unitdate label="P&#xE4;&#xE4;asiallinen ajallinen kattavuus" normal="1992-uu-uu/1993-12-31">xx.xx.1992-31.12.1993</unitdate>
+    <unitdate label="Ajallinen kattavuus" normal="1970-uu-uu/1971-uu-uu">xx.xx.1970-xx.xx.1971</unitdate>
+  </did>
+</record>

--- a/tests/fixtures/finna/record/ahaa13.xml
+++ b/tests/fixtures/finna/record/ahaa13.xml
@@ -1,0 +1,31 @@
+<record>
+  <control>
+    <recordid>123</recordid>
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="3.1.2" lang="fin"></titleproper>
+        <author></author>
+      </titlestmt>
+      <publicationstmt>
+        <publisher></publisher>
+      </publicationstmt>
+    </filedesc>
+    <maintenancestatus value="derived"/>
+    <maintenanceagency>
+      <agencycode lang="eng"></agencycode>
+    </maintenanceagency>
+    <maintenancehistory>
+      <maintenanceevent>
+        <eventtype value=""/>
+        <eventdatetime/>
+        <agenttype value=""/>
+        <agent/>
+      </maintenanceevent>
+    </maintenancehistory>
+  </control>
+  <did>
+    <unitid />
+    <unitdate label="P&#xE4;&#xE4;asiallinen ajallinen kattavuus" normal="1992-uu-uu/1993-12-31">xx.xx.1992-31.12.1993</unitdate>
+    <unitdate label="Ajallinen kattavuus" normal="unknown/open"></unitdate>
+  </did>
+</record>

--- a/tests/fixtures/finna/record/yksa.xml
+++ b/tests/fixtures/finna/record/yksa.xml
@@ -1,0 +1,35 @@
+<record>
+  <control>
+    <recordid>FSD3390</recordid>
+    <filedesc>
+      <titlestmt>
+        <titleproper lang="fi">Tampereen kaupungin aikuissosiaalityön asiakaskysely 2014</titleproper>
+      </titlestmt>
+    </filedesc>
+    <maintenancestatus value="derived"/>
+    <maintenanceagency>
+      <agencyname lang="fi">Yhteiskuntatieteellinen tietoarkisto</agencyname>
+    </maintenanceagency>
+    <maintenancehistory>
+      <maintenanceevent>
+        <eventtype value="derived"/>
+        <eventdatetime/>
+        <agenttype value="machine"/>
+        <agent/>
+      </maintenanceevent>
+    </maintenancehistory>
+  </control>
+  <did>
+    <unitid identifier="FSD3390">FSD3390</unitid>
+    <unittitle lang="fi">Tampereen kaupungin aikuissosiaalityön asiakaskysely 2014</unittitle>
+    <langmaterial>
+      <language lang="fi"/>
+    </langmaterial>
+    <daoset>
+      <dao daotype="derived" lang="fi" href="http://urn.fi/urn:nbn:fi:fsd:T-FSD3390">
+        <descriptivenote><p lang="fi">Yhteiskuntatieteellinen tietoarkisto FSD</p></descriptivenote>
+      </dao>
+    </daoset>
+    <unitdate>1918-1931</unitdate>
+  </did>
+</record>

--- a/tests/fixtures/finna/record/yksa2.xml
+++ b/tests/fixtures/finna/record/yksa2.xml
@@ -1,0 +1,35 @@
+<record>
+  <control>
+    <recordid>FSD3390</recordid>
+    <filedesc>
+      <titlestmt>
+        <titleproper lang="fi">Tampereen kaupungin aikuissosiaalityön asiakaskysely 2014</titleproper>
+      </titlestmt>
+    </filedesc>
+    <maintenancestatus value="derived"/>
+    <maintenanceagency>
+      <agencyname lang="fi">Yhteiskuntatieteellinen tietoarkisto</agencyname>
+    </maintenanceagency>
+    <maintenancehistory>
+      <maintenanceevent>
+        <eventtype value="derived"/>
+        <eventdatetime/>
+        <agenttype value="machine"/>
+        <agent/>
+      </maintenanceevent>
+    </maintenancehistory>
+  </control>
+  <did>
+    <unitid identifier="FSD3390">FSD3390</unitid>
+    <unittitle lang="fi">Tampereen kaupungin aikuissosiaalityön asiakaskysely 2014</unittitle>
+    <langmaterial>
+      <language lang="fi"/>
+    </langmaterial>
+    <daoset>
+      <dao daotype="derived" lang="fi" href="http://urn.fi/urn:nbn:fi:fsd:T-FSD3390">
+        <descriptivenote><p lang="fi">Yhteiskuntatieteellinen tietoarkisto FSD</p></descriptivenote>
+      </dao>
+    </daoset>
+    <unitdate>1931</unitdate>
+  </did>
+</record>


### PR DESCRIPTION
- Indeksoidaan ensisijassa unitdate@label="Ajallinen kattavuus" vain kun alku- ja loppuaika ovat molemmat tiedossa. Muussa tapauksessa käytetään ensimmäistä unitdatea
- Käytetään unitdaten valuea jos normal-attribuutti puuttuu
- Indeksoidaan era_facet

Lisäksi
- Korjattu unit-testin namespace
- Lisää testi-tiedostoja