### PR TITLE
[ALLI-5944] EAD3: index origination to authors

### DIFF
--- a/src/RecordManager/Base/Record/Ead3.php
+++ b/src/RecordManager/Base/Record/Ead3.php
@@ -125,7 +125,6 @@ class Ead3 extends Ead
         $data['author'] = $this->getAuthors();
         $data['author_sort'] = reset($data['author']);
         $data['author_corporate'] = $this->getCorporateAuthors();
-        $data['author2'] = $this->getSecondaryAuthors();
         $data['geographic'] = $data['geographic_facet']
             = $this->getGeographicTopics();
         $data['topic'] = $data['topic_facet'] = $this->getTopics();
@@ -244,6 +243,11 @@ class Ead3 extends Ead
                 }
             }
         }
+        if (isset($this->doc->did->origination->persname)) {
+            foreach ($this->doc->did->origination->persname as $name) {
+                $result[] = trim((string)$name);
+            }
+        }
         return $result;
     }
 
@@ -272,22 +276,6 @@ class Ead3 extends Ead
                     $result[] = trim((string)$part);
                 }
             }
-        }
-        return $result;
-    }
-
-    /**
-     * Get secondary authors
-     *
-     * @return array
-     */
-    protected function getSecondaryAuthors()
-    {
-        $result = [];
-        if (!empty($this->doc->did->origination->persname)) {
-            $result[] = trim(
-                (string)$this->doc->did->origination->persname
-            );
         }
         return $result;
     }

--- a/src/RecordManager/Finna/Record/Ead3.php
+++ b/src/RecordManager/Finna/Record/Ead3.php
@@ -267,6 +267,15 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
             }
         }
 
+        foreach ($this->doc->did->origination->persname ?? [] as $name) {
+            $data['author'][] = $data['author_facet'][] = (string)$name;
+        }
+        foreach ($this->doc->did->origination->name ?? [] as $name) {
+            foreach ($name->part ?? [] as $part) {
+                $data['author'][] = $data['author_facet'][] = (string)$part;
+            }
+        }
+
         if (isset($doc->index->index->indexentry)) {
             foreach ($doc->index->index->indexentry as $indexentry) {
                 if (isset($indexentry->name->part)) {
@@ -348,6 +357,16 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
             $result[] = trim((string)$relation->relationentry);
         }
         return $result;
+    }
+
+    /**
+     * Get secondary authors
+     *
+     * @return array
+     */
+    protected function getSecondaryAuthors()
+    {
+        return [];
     }
 
     /**

--- a/src/RecordManager/Finna/Record/Ead3.php
+++ b/src/RecordManager/Finna/Record/Ead3.php
@@ -360,16 +360,6 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
     }
 
     /**
-     * Get secondary authors
-     *
-     * @return array
-     */
-    protected function getSecondaryAuthors()
-    {
-        return [];
-    }
-
-    /**
      * Get author identifiers
      *
      * @return array


### PR DESCRIPTION
author2 palautetaan tyhjänä koska muuten origination>persname indeksoituisi myös sinne Base/Ead3:n kautta:
https://github.com/NatLibFi/RecordManager/blob/dev/src/RecordManager/Base/Record/Ead3.php#L284 