### PR TITLE
[ALLI-6830] EAD3: handle linebreaks in description

### DIFF
--- a/src/RecordManager/Finna/Record/Ead3.php
+++ b/src/RecordManager/Finna/Record/Ead3.php
@@ -787,7 +787,10 @@ class Ead3 extends \RecordManager\Base\Record\Ead3
             $desc = [];
             foreach ($this->doc->scopecontent as $el) {
                 foreach ($el->p as $p) {
-                    $desc[] = trim(html_entity_decode((string)$p));
+                    $desc[] = str_replace(
+                        ["\r\n", "\n\r", "\r", "\n"], '   /   ',
+                        trim(html_entity_decode((string)$p))
+                    );
                 }
             }
             if (!empty($desc)) {


### PR DESCRIPTION
Korvaa yksittäisen scopecontent->p:n sisältämät rivinvaihdot `'   /   ' ` -erottimella (samalla tavalla yhdistetään toistuvat scopecontent->p:t: https://github.com/NatLibFi/RecordManager/blob/dev/src/RecordManager/Finna/Record/Ead3.php#L794)