### PR TITLE
LIDO: Use driverparam when deciding default language

### DIFF
--- a/src/RecordManager/Base/Record/Lido.php
+++ b/src/RecordManager/Base/Record/Lido.php
@@ -878,7 +878,7 @@ class Lido extends AbstractRecord
      */
     protected function getDefaultLanguage()
     {
-        return 'en';
+        return $this->getDriverParam('defaultDisplayLanguage', 'en');;
     }
 
     /**

--- a/src/RecordManager/Base/Record/Lido.php
+++ b/src/RecordManager/Base/Record/Lido.php
@@ -878,7 +878,7 @@ class Lido extends AbstractRecord
      */
     protected function getDefaultLanguage()
     {
-        return $this->getDriverParam('defaultDisplayLanguage', 'en');;
+        return $this->getDriverParam('defaultDisplayLanguage', 'en');
     }
 
     /**


### PR DESCRIPTION
Returns 'en' if no value has been found