### PR TITLE
Fix configuration file typo.

### DIFF
--- a/conf/datasources.ini.sample
+++ b/conf/datasources.ini.sample
@@ -81,7 +81,7 @@
 ; authority[<type>]     Map to authority index sources where <type> is authority record type
 ;                       (corporateBody, person) or * for any;
 ; authority_id_regex[<type>] Regex for filtering allowed authority ids
-:                            (used when indexing authority ids and when enriching biblio records with MarcAuthEnrichment)
+;                            (used when indexing authority ids and when enriching biblio records with MarcAuthEnrichment)
 ; fullTextXPaths        XPath expression denoting full text fields
 ; fullTextUrlXPaths     XPath expression denoting fields that contain URLs to full text content (plain text only at the moment)
 


### PR DESCRIPTION
This was causing a parse error when I copied the sample configuration to an active one.