### PR TITLE
Add setting to limit the amount of injected GeniePlus holdings data.

### DIFF
--- a/conf/datasources.ini.sample
+++ b/conf/datasources.ini.sample
@@ -208,6 +208,13 @@ geniePlusLocationField = Inventory.Location.CodeDesc
 geniePlusSublocationField = Inventory.SubLoc.CodeDesc
 geniePlusCallnumberField = Inventory.CallNumLC
 geniePlusBarcodeField = Inventory.Barcode
+; When injecting 852 fields, you can limit the number of barcodes injected per
+; location-sublocation-callnumber combination in order to control the length
+; of generated MARC records. If you only need to index holdings-level data
+; instead of item-level data, it is recommended that you set this to 1. If you
+; do not want any location data, set it to 0. You can set it to -1 for no limit
+; (the default setting).
+geniePlusItemLimitPerLocationGroup = -1
 ; These settings control the MARC field/subfield in which unique GeniePlus IDs will
 ; be injected:
 geniePlusUniqueIdOutputField = 999

--- a/src/RecordManager/Base/Harvest/GeniePlus.php
+++ b/src/RecordManager/Base/Harvest/GeniePlus.php
@@ -622,7 +622,7 @@ class GeniePlus extends AbstractBase
             if (empty($barcode) && $groupKey === '--') {
                 continue;
             }
-            if (!isset($result[$groupKey])) {
+            if (!isset($groups[$groupKey])) {
                 $groups[$groupKey] = [];
             }
             $groups[$groupKey][] = [
@@ -643,7 +643,7 @@ class GeniePlus extends AbstractBase
      *
      * @return array
      */
-    protected function getHoldings($record): array
+    protected function getHoldings(array $record): array
     {
         // Special case: short circuit if disabled:
         if ($this->itemLimitPerLocationGroup === 0) {


### PR DESCRIPTION
This PR creates a setting to limit (or entirely disable) GeniePlus holdings injection, to prevent unconstrained growth of MARC records in scenarios where holdings data is not needed.

TODO
- [ ] Run full test harvest and confirm appropriate results