### PR TITLE
[ALLI-6920] OnkiLightEnrichment: enrich records with available WGS 84 data

### DIFF
--- a/conf/recordmanager.ini.sample
+++ b/conf/recordmanager.ini.sample
@@ -283,6 +283,11 @@ replace[] = '\1 street'
 ;url_prefix_allowed_list[] = "http://somewhere/"
 ; URI prefixes where exact matches in other vocabularies are also retrieved
 ;uri_prefix_exact_matches[] = "http://somewhere/vocab/"
+; Solr field that contains the location data
+;solr_location_field = location_geo
+; Solr field that contains centroids for the locations. Set to empty if no suitable
+; field is available.
+;solr_center_field = center_coords
 
 [MusicBrainzEnrichment]
 ; Note that you need to add the following line to any data source in datasources.ini

--- a/dbscripts/mysql.sql
+++ b/dbscripts/mysql.sql
@@ -67,6 +67,7 @@ CREATE TABLE `ontologyEnrichment` (
   `prefLabels` MEDIUMTEXT NULL,
   `altLabels` MEDIUMTEXT NULL,
   `hiddenLabels` MEDIUMTEXT NULL
+  `geoLocation` MEDIUMTEXT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `logMessage` (

--- a/src/RecordManager/Base/Enrichment/NominatimGeocoder.php
+++ b/src/RecordManager/Base/Enrichment/NominatimGeocoder.php
@@ -243,9 +243,9 @@ class NominatimGeocoder extends AbstractEnrichment
     protected function enrichLocations($locations, &$solrArray)
     {
         $result = false;
-        $center = !empty($this->solrCenterField) &&
-            isset($solrArray[$this->solrCenterField]) ?
-            \geoPHP::load('POINT(' . $solrArray[$this->solrCenterField] . ')', 'wkt')
+        $cf = $this->solrCenterField;
+        $center = $cf && isset($solrArray[$cf])
+            ? \geoPHP::load('POINT(' . $solrArray[$cf] . ')', 'wkt')
             : null;
 
         foreach ($locations as $location) {
@@ -274,10 +274,8 @@ class NominatimGeocoder extends AbstractEnrichment
                     }
                     // Set new center coordinates only if the field is in use and has
                     // no previous value
-                    if (!empty($this->solrCenterField)
-                        && !isset($solrArray[$this->solrCenterField])
-                    ) {
-                        $solrArray[$this->solrCenterField]
+                    if ($cf && !isset($solrArray[$cf])) {
+                        $solrArray[$cf]
                             = $geocoded[0]['lon'] . ' ' . $geocoded[0]['lat'];
                     }
                     $result = true;

--- a/src/RecordManager/Base/Enrichment/OnkiLightEnrichment.php
+++ b/src/RecordManager/Base/Enrichment/OnkiLightEnrichment.php
@@ -251,28 +251,29 @@ abstract class OnkiLightEnrichment extends AbstractEnrichment
                 } elseif ($item['type'] != 'skos:Concept') {
                     continue;
                 }
-                $vals = [];
-                if ($val = $item['altLabel']['value'] ?? null) {
-                    $vals[] = $val;
-                }
-                if ($val = $item['hiddenLabel']['value'] ?? null) {
-                    $vals[] = $val;
-                }
 
-                if ($item['uri'] == $id) {
+                if ($item['uri'] === $id) {
                     $this->processLocationWgs84($item, $solrArray);
-                }
+                    $vals = [];
 
-                if ($item['uri'] == $id && $vals) {
-                    foreach ($this->filterDuplicates($vals, $checkFieldContents)
-                        as $val
-                    ) {
-                        $checkFieldContents[] = mb_strtolower($val, 'UTF-8');
-                        if ($solrAltField) {
-                            $solrArray[$solrAltField][] = $val;
-                        }
-                        if ($includeInAllfields) {
-                            $solrArray['allfields'][] = $val;
+                    if ($val = $item['altLabel']['value'] ?? null) {
+                        $vals[] = $val;
+                    }
+                    if ($val = $item['hiddenLabel']['value'] ?? null) {
+                        $vals[] = $val;
+                    }
+
+                    if ($vals) {
+                        foreach ($this->filterDuplicates($vals, $checkFieldContents)
+                            as $val
+                        ) {
+                            $checkFieldContents[] = mb_strtolower($val, 'UTF-8');
+                            if ($solrAltField) {
+                                $solrArray[$solrAltField][] = $val;
+                            }
+                            if ($includeInAllfields) {
+                                $solrArray['allfields'][] = $val;
+                            }
                         }
                     }
                 }
@@ -432,7 +433,7 @@ abstract class OnkiLightEnrichment extends AbstractEnrichment
             $wktItem = [
                 'lat' => $lat,
                 'lon' => $lon,
-                'wkt' => 'POINT(' . $lon . ' ' . $lat . ')'
+                'wkt' => "POINT($lon $lat)"
             ];
             $this->processLocationItem($wktItem, $solrArray);
         }
@@ -448,9 +449,7 @@ abstract class OnkiLightEnrichment extends AbstractEnrichment
      */
     protected function processLocationItem($locItem, &$solrArray): void
     {
-        if (!empty($this->solrCenterField)
-            && !isset($solrArray[$this->solrCenterField])
-        ) {
+        if ($this->solrCenterField && !isset($solrArray[$this->solrCenterField])) {
             $coords = $locItem['lon'] . ' ' . $locItem['lat'];
             $solrArray[$this->solrCenterField] = $coords;
         }

--- a/utils/fetch_finto.post
+++ b/utils/fetch_finto.post
@@ -1,11 +1,13 @@
 query=PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX wgs84: <http://www.w3.org/2003/01/geo/wgs84_pos#>
 SELECT
-	(?uri AS ?_id)
-	('finto' as ?type)
+    (?uri AS ?_id)
+    ('finto' as ?type)
     (GROUP_CONCAT(DISTINCT STR(?prefLabel); separator='|') AS ?prefLabels)
     (GROUP_CONCAT(DISTINCT STR(?altLabel); separator='|') AS ?altLabels)
     (GROUP_CONCAT(DISTINCT STR(?hiddenLabel); separator='|') AS ?hiddenLabels)
+    (CONCAT('POINT(', SAMPLE(?long), ' ', SAMPLE(?lat), ')') AS ?geoLocation)
 WHERE {
   VALUES ?graph {
     <http://www.yso.fi/onto/yso/>
@@ -24,6 +26,10 @@ WHERE {
     }
     OPTIONAL {
       ?uri skos:hiddenLabel ?hiddenLabel
+    }
+    OPTIONAL {
+      ?uri wgs84:lat ?lat .
+      ?uri wgs84:long ?long .
     }
   }
 }


### PR DESCRIPTION
Few notes:

1. OnkiLightEnrichment may yield many points to `location_geo` field in case `$localData` is false but only the first one is considered the centroid one (if none exists before).
2. OnkiLightEnrichment: as class variables `solrLocationField` and `solrCenterField` are initialized in the class file, I believe that pre-existing installations of RecordManager will readily use them without configuration changes. This may or may not introduce unwanted consequences.
3. Enrichment\NominatimGeocoder will now check for pre-existing centroid value and add polygon(s) to Solr location field only if the centroid is included in the polygon.
4. Additionally [related to ALLI-6920], if, for example, NominatimCoder is wanted to be applied after, let's say, `MarcOnkiLightEnrichment`, one must pay attention to how enrichments are added and their respective execution order:
    a. Globally declared enrichments added via Solr configuration `enrichment` array are called "first" (of course setting the enrichment stage affects this in a way), see code below: https://github.com/NatLibFi/RecordManager/blob/b7913fdcabdc6f9128e59fc0b6384af908fc0633/src/RecordManager/Base/Solr/SolrUpdater.php#L2754-L2775
    b. In order to tackle some issues described in a), one could just simply add enrichments via numbers, e.g., `enrichments[n] = MarcOnkiLightEnrichment;` `enrichments[n+1] = NominatimGeocoder`; however, this method is not powerful enough to 'beat' the boundary of globally declared enrichments and datasource enrichments. Solely on the datasource configuration side, however, this would work.

All in all, please note that any Solr field value is left unchanged and may not be updated by the code - only additions are made.

