### PR TITLE
Clean up solr:update-index and solr:compare-records output

### DIFF
--- a/src/RecordManager/Base/Enrichment/OnkiLightEnrichment.php
+++ b/src/RecordManager/Base/Enrichment/OnkiLightEnrichment.php
@@ -178,6 +178,14 @@ abstract class OnkiLightEnrichment extends AbstractEnrichment
                     explode('|', $localData[$labelField] ?? ''),
                     $checkFieldContents
                 );
+                // Additionally, filter empty strings
+                $values = array_filter(
+                    $values,
+                    fn ($v) => !is_string($v) || '' !== trim($v)
+                );
+                if (empty($values)) {
+                    continue;
+                }
                 if ($solrField) {
                     $solrArray[$solrField]
                         = array_merge($solrArray[$solrField] ?? [], $values);


### PR DESCRIPTION
Previously empty string additions could have been shown when executing `./console solr:update-index --no-commit ...` or `./console solr:compare-records ...` in case of OnkiLightEnrichment found `$localData` and the requested data field was empty. This PR fixes these inconveniences.