### PR TITLE
[ALLI-7749] LIDO: Do not index related works with no relation type

### DIFF
--- a/src/RecordManager/Base/Record/Lido.php
+++ b/src/RecordManager/Base/Record/Lido.php
@@ -1269,7 +1269,6 @@ class Lido extends AbstractRecord
             ->relatedWorksWrap->relatedWorkSet as $relatedWorkSetNode
         ) {
             if (empty($relatedWorkRelType)
-                || empty($relatedWorkSetNode->relatedWorkRelType->term)
                 || in_array(
                     trim(
                         mb_strtolower(

--- a/src/RecordManager/Base/Record/Lido.php
+++ b/src/RecordManager/Base/Record/Lido.php
@@ -1268,16 +1268,14 @@ class Lido extends AbstractRecord
         foreach ($this->doc->lido->descriptiveMetadata->objectRelationWrap
             ->relatedWorksWrap->relatedWorkSet as $relatedWorkSetNode
         ) {
-            if (empty($relatedWorkRelType)
-                || in_array(
-                    trim(
-                        mb_strtolower(
-                            $relatedWorkSetNode->relatedWorkRelType->term,
-                            'UTF-8'
-                        )
-                    ),
-                    $relatedWorkRelType
+            $relType = trim(
+                mb_strtolower(
+                    $relatedWorkSetNode->relatedWorkRelType->term ?? '',
+                    'UTF-8'
                 )
+            );
+            if (empty($relatedWorkRelType)
+                || in_array($relType, $relatedWorkRelType)
             ) {
                 $setList[] = $relatedWorkSetNode;
             }


### PR DESCRIPTION
A related work without a relation type could be any kind of relation, so it should not be included when indexing related works to collection and hierarchy fields.