### PR TITLE
[ALLI-7881] QDC: Fix handling publication year ranges separated by a slash

### DIFF
--- a/src/RecordManager/Base/Record/Qdc.php
+++ b/src/RecordManager/Base/Record/Qdc.php
@@ -366,7 +366,7 @@ class Qdc extends AbstractRecord
             $date = trim($date);
             if (preg_match('{^(\d{4})$}', $date)) {
                 return $date;
-            } elseif (preg_match('{^(\d{4})-}', $date, $matches)) {
+            } elseif (preg_match('{^(\d{4})(-|\/)}', $date, $matches)) {
                 return $matches[1];
             }
         }
@@ -374,7 +374,7 @@ class Qdc extends AbstractRecord
             $date = trim($date);
             if (preg_match('{^(\d{4})$}', $date)) {
                 return $date;
-            } elseif (preg_match('{^(\d{4})-}', $date, $matches)) {
+            } elseif (preg_match('{^(\d{4})(-|\/)}', $date, $matches)) {
                 return $matches[1];
             }
         }


### PR DESCRIPTION
Support year ranges expressed according to ISO 8601 [YYYY/YYYY]