### PR TITLE
[ALLI-7737] LIDO: Improve handling titles that equal work type

### DIFF
--- a/src/RecordManager/Base/Record/Lido.php
+++ b/src/RecordManager/Base/Record/Lido.php
@@ -436,6 +436,7 @@ class Lido extends AbstractRecord
         }
         $mergeValues = $this->getDriverParam('mergeTitleValues', true);
         $mergeSets = $this->getDriverParam('mergeTitleSets', true);
+        $formatInTitle = $this->getDriverParam('allowTitleToMatchFormat', false);
         $preferredTitles = [];
         $alternateTitles = [];
         $defaultLanguage = $this->getDefaultLanguage();
@@ -524,15 +525,14 @@ class Lido extends AbstractRecord
         // name given here and the object type, recorded in the object / work
         // type element are often identical."
         $workType = $this->getObjectWorkType();
-        if (strcasecmp($workType, $preferred) == 0) {
+        if (!$formatInTitle && strcasecmp($workType, $preferred) == 0) {
             $descriptionWrapDescriptions = [];
             $nodes = $this->getObjectDescriptionSetNodes(
                 $this->descriptionTypesExcludedFromTitle
             );
             foreach ($nodes as $set) {
-                if ($set->descriptiveNoteValue) {
-                    $descriptionWrapDescriptions[]
-                        = (string)$set->descriptiveNoteValue;
+                if ($value = trim((string)($set->descriptiveNoteValue ?? ''))) {
+                    $descriptionWrapDescriptions[] = $value;
                 }
             }
             if ($descriptionWrapDescriptions) {

--- a/src/RecordManager/Base/Record/Lido.php
+++ b/src/RecordManager/Base/Record/Lido.php
@@ -519,7 +519,7 @@ class Lido extends AbstractRecord
         }
         $alternate = array_values(array_unique(array_column($alternateTitles, 0)));
 
-        // Use description if title is the same as the work type
+        // If configured, use description if title is the same as the work type.
         // From LIDO specs:
         // "For objects from natural, technical, cultural history e.g. the object
         // name given here and the object type, recorded in the object / work

--- a/tests/RecordManagerTest/Base/Record/LidoTest.php
+++ b/tests/RecordManagerTest/Base/Record/LidoTest.php
@@ -266,6 +266,40 @@ class LidoTest extends RecordTest
     }
 
     /**
+     * Test LIDO title handling when title equals work type
+     *
+     * @return void
+     */
+    public function testLido3TitleEqualsWorkType()
+    {
+        $record = $this->createRecord(Lido::class, 'lido3.xml');
+        $fields = $record->toSolrArray();
+
+        $this->assertEquals('Maisema', $fields['title']);
+        $this->assertEquals('Maisema', $fields['title_full']);
+        $this->assertEquals('Maisema', $fields['title_short']);
+        $this->assertEquals('Maisema', $fields['title_sort']);
+
+        $record = $this->createRecord(
+            Lido::class,
+            'lido3.xml',
+            [
+                '__unit_test_no_source__' => [
+                    'driverParams' => [
+                        'allowTitleToMatchFormat=true'
+                    ]
+                ]
+            ]
+        );
+        $fields = $record->toSolrArray();
+
+        $this->assertEquals('Maalaus', $fields['title']);
+        $this->assertEquals('Maalaus', $fields['title_full']);
+        $this->assertEquals('Maalaus', $fields['title_short']);
+        $this->assertEquals('Maalaus', $fields['title_sort']);
+    }
+
+    /**
      * Test LIDO work identification data handling
      *
      * @return void

--- a/tests/fixtures/Base/record/lido3.xml
+++ b/tests/fixtures/Base/record/lido3.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<lidoWrap schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+  <lido>
+    <lidoRecID type="Test">12345</lidoRecID>
+    <descriptiveMetadata lang="en">
+      <objectClassificationWrap>
+        <objectWorkTypeWrap>
+          <objectWorkType>
+            <term>Maalaus</term>
+          </objectWorkType>
+        </objectWorkTypeWrap>
+      </objectClassificationWrap>
+      <objectIdentificationWrap>
+        <titleWrap>
+          <titleSet>
+            <appellationValue>Maalaus</appellationValue>
+          </titleSet>
+        </titleWrap>
+        <objectDescriptionWrap>
+            <objectDescriptionSet type="description">
+                <descriptiveNoteValue>Maisema</descriptiveNoteValue>
+            </objectDescriptionSet>
+        </objectDescriptionWrap>
+      </objectIdentificationWrap>
+    </descriptiveMetadata>
+  </lido>
+</lidoWrap>


### PR DESCRIPTION
Add an option not to replace title with description when title equals work type. Also avoid replacing title with empty description.