### PR TITLE
Add authority folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Thumbs.db
 .vscode
 
 # Local files
+authority
 conf/*.ini
 conf/*.lst
 .php_cs_cache


### PR DESCRIPTION
Easier to manage authority folder when it does not get accidentally deleted in certain situations.