### PR TITLE
[FINNA-1997] Add an option to apply XSL transformation when exporting files

### DIFF
--- a/src/RecordManager/Base/Command/Records/Export.php
+++ b/src/RecordManager/Base/Command/Records/Export.php
@@ -258,9 +258,9 @@ class Export extends AbstractBase
     protected $noRoot;
 
     /**
-     * Configuration file for optional XSL transformation to be applied to records
+     * XslTransformation
      *
-     * @var string
+     * @var ?XslTransformation
      */
     protected $xslTransformation;
 
@@ -300,12 +300,8 @@ class Export extends AbstractBase
             }
         }
         $xmlStr = $metadataRecord->toXML();
-        if ($this->transformBeforeXPath && $propertiesFile = $this->xslTransformation) {
-            $transformation = new XslTransformation(
-                RECMAN_BASE_PATH . '/transformations',
-                $propertiesFile
-            );
-            $xmlStr = $transformation->transform($xmlStr);
+        if ($this->transformBeforeXPath && isset($this->xslTransformation)) {
+            $xmlStr = $this->xslTransformation->transform($xmlStr);
         }
         $needsInjection = $this->injectId
             || $this->injectIdPrefixed
@@ -378,12 +374,8 @@ class Export extends AbstractBase
                 $xmlStr = $xml->saveXML();
             }
         }
-        if (!$this->transformBeforeXPath && $propertiesFile = $this->xslTransformation) {
-            $transformation = new XslTransformation(
-                RECMAN_BASE_PATH . '/transformations',
-                $propertiesFile
-            );
-            $xmlStr = $transformation->transform($xmlStr);
+        if (!$this->transformBeforeXPath && isset($this->xslTransformation)) {
+            $xmlStr = $this->xslTransformation->transform($xmlStr);
         }
         ++$this->count;
         if ($record['deleted']) {
@@ -616,7 +608,12 @@ class Export extends AbstractBase
             $this->additionalNamespaces[$parts[0]] = $parts[1];
         }
         $this->noRoot = ($input->getOption('no-root') && ($this->batchSize == 1 || $this->singleId));
-        $this->xslTransformation = $input->getOption('xslt');
+        if ($config = $input->getOption('xslt')) {
+            $this->xslTransformation = new XslTransformation(
+                RECMAN_BASE_PATH . '/transformations',
+                $config
+            );
+        }
         $this->transformBeforeXPath = $input->getOption('xslt-first');
     }
 

--- a/src/RecordManager/Base/Command/Records/Export.php
+++ b/src/RecordManager/Base/Command/Records/Export.php
@@ -258,7 +258,7 @@ class Export extends AbstractBase
     protected $noRoot;
 
     /**
-     * XslTransformation
+     * Optional XSL transformation to be applied to records
      *
      * @var ?XslTransformation
      */

--- a/src/RecordManager/Base/Command/Records/Export.php
+++ b/src/RecordManager/Base/Command/Records/Export.php
@@ -262,7 +262,7 @@ class Export extends AbstractBase
      *
      * @var ?XslTransformation
      */
-    protected $xslTransformation;
+    protected $xslTransformation = null;
 
     /**
      * Apply XSL transformation before trying to match XPath expression
@@ -300,7 +300,7 @@ class Export extends AbstractBase
             }
         }
         $xmlStr = $metadataRecord->toXML();
-        if ($this->transformBeforeXPath && isset($this->xslTransformation)) {
+        if ($this->transformBeforeXPath && null !== $this->xslTransformation) {
             $xmlStr = $this->xslTransformation->transform($xmlStr);
         }
         $needsInjection = $this->injectId
@@ -374,7 +374,7 @@ class Export extends AbstractBase
                 $xmlStr = $xml->saveXML();
             }
         }
-        if (!$this->transformBeforeXPath && isset($this->xslTransformation)) {
+        if (!$this->transformBeforeXPath && null !== $this->xslTransformation) {
             $xmlStr = $this->xslTransformation->transform($xmlStr);
         }
         ++$this->count;
@@ -561,7 +561,7 @@ class Export extends AbstractBase
                 'xslt',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Configuration file for optional XSL transformation to be applied to records'
+                'Optional XSL transformation to be applied to records'
             )->addOption(
                 'xslt-first',
                 null,

--- a/src/RecordManager/Base/Command/Records/Export.php
+++ b/src/RecordManager/Base/Command/Records/Export.php
@@ -552,7 +552,7 @@ class Export extends AbstractBase
                 'Do not add a root element around the XML. Works only'
                 . ' when exporting single records or with batch-size 1.'
             )->addOption(
-                'xslTransformation',
+                'xslt',
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Configuration file for optional XSL transformation to be applied to records'
@@ -596,7 +596,7 @@ class Export extends AbstractBase
             }
             $this->additionalNamespaces[$parts[0]] = $parts[1];
         }
-        $this->xslTransformation = $input->getOption('xslTransformation');
+        $this->xslTransformation = $input->getOption('xslt');
         $this->noRoot = ($input->getOption('no-root') && ($this->batchSize == 1 || $this->singleId));
     }
 

--- a/src/RecordManager/Base/Command/Records/Export.php
+++ b/src/RecordManager/Base/Command/Records/Export.php
@@ -549,7 +549,8 @@ class Export extends AbstractBase
                 'no-root',
                 null,
                 InputOption::VALUE_NONE,
-                'Do not add a root element around the XML. Works only when exporting single records or with batch-size 1.'
+                'Do not add a root element around the XML. Works only'
+                . ' when exporting single records or with batch-size 1.'
             )->addOption(
                 'xslTransformation',
                 null,


### PR DESCRIPTION
Including an option to do transformation before or after trying to match an XPath expression. Also added an option not to add a collection root element when exporting XML files that contain only one record.