### PR TITLE
Changed timestamp from $fromTimestamp to $earliestRecordTimestamp

### DIFF
--- a/src/RecordManager/Base/Solr/SolrUpdater.php
+++ b/src/RecordManager/Base/Solr/SolrUpdater.php
@@ -1003,7 +1003,7 @@ class SolrUpdater
                     // timestamp:
                     $earliestRecordTimestamp -= 5;
                     $dedupParams['changed']
-                        = ['$gte' => $this->db->getTimestamp($fromTimestamp)];
+                        = ['$gte' => $this->db->getTimestamp($earliestRecordTimestamp)];
                     $this->log->logInfo(
                         'updateRecords',
                         'Processing dedup records from '


### PR DESCRIPTION
In line 1006 the variable `$fromTimestamp` is used as the filter for the update of dedup records. In this if-clause the timestamp `$earliestRecordTimestamp` should be used, as changed dedup records are meant to be processed. Using `$fromTimestamp` does leave an inconsistent state in the dedup entries in the index.