### PR TITLE
Check that a candidate for deduplication is in a source that is configured for deduplication

### DIFF
--- a/src/RecordManager/Base/Deduplication/DedupHandler.php
+++ b/src/RecordManager/Base/Deduplication/DedupHandler.php
@@ -478,7 +478,7 @@ class DedupHandler implements DedupHandlerInterface
                 if (empty($this->dataSourceConfig[$candidate['source_id']]['dedup'])) {
                     continue;
                 }
-                
+
                 // Check that we haven't already tried this candidate
                 if (isset($noMatchRecordIds[$candidate['_id']])) {
                     continue;

--- a/src/RecordManager/Base/Deduplication/DedupHandler.php
+++ b/src/RecordManager/Base/Deduplication/DedupHandler.php
@@ -474,6 +474,11 @@ class DedupHandler implements DedupHandlerInterface
             $processed = 0;
             // Go through the candidates, try to match
             foreach ($candidates as $candidate) {
+                // Check that the candidate is in a source that is configured for deduplication
+                if (empty($this->dataSourceConfig[$candidate['source_id']]['dedup'])) {
+                    continue;
+                }
+                
                 // Check that we haven't already tried this candidate
                 if (isset($noMatchRecordIds[$candidate['_id']])) {
                     continue;

--- a/src/RecordManager/Base/Solr/SolrUpdater.php
+++ b/src/RecordManager/Base/Solr/SolrUpdater.php
@@ -1003,7 +1003,7 @@ class SolrUpdater
                     // timestamp:
                     $earliestRecordTimestamp -= 5;
                     $dedupParams['changed']
-                        = ['$gte' => $this->db->getTimestamp($fromTimestamp)];
+                        = ['$gte' => $this->db->getTimestamp($earliestRecordTimestamp)];
                     $this->log->logInfo(
                         'updateRecords',
                         'Processing dedup records from '


### PR DESCRIPTION
We experienced the following behaviour with deduplication:

Sources configured:

- Source  1  (dedup = true)
- Source  2  (dedup = true)
- Source  3  (dedup = true)
- Source  4 (dedup = false) 

When running deduplication (with or without explicitly stating the sources to be deduplicated with  `--source`), records from sourced 1 to 3 where not only deduplicated within this group, but also against source 4. We where expecting only the records from sources  that  are configured for deduplication to be deduplicated.

The RecordManager seems to get candidates for deduplication from the whole database. The additional code checks if the source of a deduplication candidate is configured for deduplication.