### PR TITLE
[FINNA-4364] Add support for language versions of title fields

### DIFF
--- a/conf/recordmanager.ini.sample
+++ b/conf/recordmanager.ini.sample
@@ -296,6 +296,15 @@ dewey-ones = dewey_ones.map
 ;language = language_codes.map
 ;media_type_str_mv = media_type_default.map
 
+; The following section contains mappings from metadata language codes
+; to normalized ISO 639-1 language codes
+[Metadata Language Code Mappings]
+fin = fi
+swe = sv
+en-gb = en
+eng = en
+sme = se
+
 [NominatimGeocoder]
 ; Please see http://wiki.openstreetmap.org/wiki/Nominatim_usage_policy before using
 ; Nominatim at http://nominatim.openstreetmap.org/search.php. Preferably use a local

--- a/src/RecordManager/Base/Record/Ead3.php
+++ b/src/RecordManager/Base/Record/Ead3.php
@@ -261,7 +261,7 @@ class Ead3 extends Ead
             return '';
         }
         $shortTitle = $language ? $titleLang : $this->getShortTitle();
-        $titleSub = $this->getTitleSub();
+        $titleSub = $this->getTitleSubByLanguage($language);
         // Ini handling returns true as '1':
         $prependTitle = $this->getDriverParam('prependTitleWithSubtitle', '1');
         if (
@@ -282,6 +282,19 @@ class Ead3 extends Ead
         }
 
         return $this->resultCache[$key] = $title;
+    }
+
+    /**
+     * Return subtitle by language
+     *
+     * @param ?string $language Return subtitle with specific language code (for downstream usage).
+     *
+     * @return string
+     */
+    protected function getTitleSubByLanguage($language = null): string
+    {
+        // Subtitle is currently not language specific
+        return $this->getTitleSub();
     }
 
     /**

--- a/src/RecordManager/Base/Record/Ead3.php
+++ b/src/RecordManager/Base/Record/Ead3.php
@@ -230,14 +230,38 @@ class Ead3 extends Ead
      */
     public function getTitle($forFiling = false): string
     {
-        if (isset($this->resultCache[__METHOD__])) {
-            return $this->resultCache[__METHOD__];
+        return $this->getTitleByLanguage($forFiling);
+    }
+
+    /**
+     * Get title by language
+     *
+     * @param bool    $forFiling Whether the title is to be used in filing
+     *                           (e.g. sorting, non-filing characters
+     *                           should be removed)
+     * @param ?string $language  Return title with specific language code (for downstream usage).
+     *                           Otherwise returns first title.
+     *
+     * @return string
+     */
+    protected function getTitleByLanguage($forFiling = false, ?string $language = null): string
+    {
+        $key = __METHOD__ . ($forFiling ? '1' : '0') . ($language ?? '');
+        if (isset($this->resultCache[$key])) {
+            return $this->resultCache[$key];
         }
-
+        $title = $titleLang = '';
+        foreach ($this->doc->did->unittitle ?? [] as $unittitle) {
+            if ($this->metadataUtils->normalizeLanguageCode($unittitle->attributes()->lang ?? '') === $language) {
+                $titleLang = (string)$unittitle;
+                break;
+            }
+        }
+        if ($language && !$titleLang) {
+            return '';
+        }
+        $shortTitle = $language ? $titleLang : $this->getShortTitle();
         $titleSub = $this->getTitleSub();
-        $shortTitle = $this->getShortTitle();
-
-        $title = '';
         // Ini handling returns true as '1':
         $prependTitle = $this->getDriverParam('prependTitleWithSubtitle', '1');
         if (
@@ -257,7 +281,7 @@ class Ead3 extends Ead
             $title = $this->metadataUtils->createSortTitle($title);
         }
 
-        return $this->resultCache[__METHOD__] = $title;
+        return $this->resultCache[$key] = $title;
     }
 
     /**
@@ -270,6 +294,8 @@ class Ead3 extends Ead
      */
     protected function postProcessRecordForIndexing(?Database $db, &$data): void
     {
+        // Additional titles should be added before adding hierarchy fields
+        $this->addAdditionalTitles($data);
         $this->addHierarchyFields($data);
     }
 
@@ -617,13 +643,35 @@ class Ead3 extends Ead
                 = (string)($this->doc->did->unittitle ?? '');
         }
         $sequenceUnitId = $sequenceUnitId ?: $firstId;
-        if (
-            $sequenceUnitId
-            && $this->getDriverParam('addIdToHierarchyTitle', true)
-        ) {
-            $data['title_in_hierarchy']
-                = trim("$sequenceUnitId " . $data['title']);
+        if ($sequenceUnitId) {
+            $this->addHierarchyTitles($data, $sequenceUnitId);
         }
+    }
+
+    /**
+     * Add hierarchy titles.
+     *
+     * @param array  $data           Reference to the target array
+     * @param string $sequenceUnitId Id to be added
+     *
+     * @return void
+     */
+    protected function addHierarchyTitles(array &$data, string $sequenceUnitId): void
+    {
+        if ($this->getDriverParam('addIdToHierarchyTitle', true)) {
+            $data['title_in_hierarchy'] = trim("$sequenceUnitId " . $data['title']);
+        }
+    }
+
+    /**
+     * Add additional titles (for downstream usage).
+     *
+     * @param array $data Reference to the target array
+     *
+     * @return void
+     */
+    protected function addAdditionalTitles(array &$data): void
+    {
     }
 
     /**

--- a/src/RecordManager/Base/Record/Ead3.php
+++ b/src/RecordManager/Base/Record/Ead3.php
@@ -658,6 +658,7 @@ class Ead3 extends Ead
      */
     protected function addHierarchyTitles(array &$data, string $sequenceUnitId): void
     {
+        // Note: title_in_hierarchy is only needed if it differs from title.
         if ($this->getDriverParam('addIdToHierarchyTitle', true)) {
             $data['title_in_hierarchy'] = trim("$sequenceUnitId " . $data['title']);
         }

--- a/src/RecordManager/Base/Record/Lido.php
+++ b/src/RecordManager/Base/Record/Lido.php
@@ -551,6 +551,7 @@ class Lido extends AbstractRecord
                 $alternateTitles[$lang][] = implode('; ', $parts);
             }
         }
+
         // Merge repeated titleSets if configured:
         if ($mergeSets) {
             foreach (array_keys($preferredTitles) as $lang) {
@@ -564,6 +565,7 @@ class Lido extends AbstractRecord
                 ];
             }
         }
+
         if (isset($preferredTitles[$defaultLanguage])) {
             $preferred = array_shift($preferredTitles[$defaultLanguage]);
         } elseif (isset($alternateTitles[$defaultLanguage])) {

--- a/src/RecordManager/Base/Record/Lido.php
+++ b/src/RecordManager/Base/Record/Lido.php
@@ -148,6 +148,15 @@ class Lido extends AbstractRecord
     ];
 
     /**
+     * Hiearchy fields included in allfields.
+     *
+     * @var array
+     */
+    protected $hierarchyFieldsInAllFields = [
+        'is_hierarchy_title', 'hierarchy_parent_title', 'hierarchy_top_title', 'title_in_hierarchy',
+    ];
+
+    /**
      * Set record data
      *
      * @param string $source    Source ID
@@ -417,6 +426,8 @@ class Lido extends AbstractRecord
      */
     protected function postProcessRecordForIndexing(?Database $db, &$data): void
     {
+        // Additional titles should be added before adding hierarchy fields
+        $this->addAdditionalTitles($data);
         $this->addHierarchyFields($data);
     }
 
@@ -484,13 +495,16 @@ class Lido extends AbstractRecord
     /**
      * Return record titles
      *
+     * @param ?string $language Only include titles in specific language (for downstream usage)
+     *
      * @return array Associative array with keys 'preferred' (string) and
      * 'alternate' (array)
      */
-    protected function getTitles()
+    protected function getTitles(?string $language = null)
     {
         $key = __METHOD__ . '/'
-            . implode(';', $this->descriptionTypesExcludedFromTitle);
+            . implode(';', $this->descriptionTypesExcludedFromTitle)
+            . ($language ?? '');
         if (isset($this->resultCache[$key])) {
             return $this->resultCache[$key];
         }
@@ -499,7 +513,7 @@ class Lido extends AbstractRecord
         $formatInTitle = $this->getDriverParam('allowTitleToMatchFormat', false);
         $preferredTitles = [];
         $alternateTitles = [];
-        $defaultLanguage = $this->getDefaultLanguage();
+        $defaultLanguage = $language ? $language : $this->getDefaultLanguage();
         foreach (
             $this->doc->lido->descriptiveMetadata->objectIdentificationWrap
             ->titleWrap->titleSet ?? [] as $set
@@ -510,12 +524,15 @@ class Lido extends AbstractRecord
                 if (!($title = trim((string)$appellationValue))) {
                     continue;
                 }
+                $titleLang =
+                    $this->metadataUtils->normalizeLanguageCode(
+                        $this->getInheritedXmlAttribute($appellationValue, 'lang')
+                    );
+                if ($language && $titleLang !== $language) {
+                    continue;
+                }
+                $titleLang = $titleLang ?: $defaultLanguage;
                 $preference = mb_strtolower((string)($appellationValue->attributes()->pref ?? 'preferred'), 'UTF-8');
-                $titleLang = $this->getInheritedXmlAttribute(
-                    $appellationValue,
-                    'lang',
-                    $defaultLanguage
-                );
                 if (in_array($preference, $this->preferredTitleTypes)) {
                     $preferredParts[$titleLang][] = $title;
                 } else {
@@ -534,7 +551,6 @@ class Lido extends AbstractRecord
                 $alternateTitles[$lang][] = implode('; ', $parts);
             }
         }
-
         // Merge repeated titleSets if configured:
         if ($mergeSets) {
             foreach (array_keys($preferredTitles) as $lang) {
@@ -548,14 +564,13 @@ class Lido extends AbstractRecord
                 ];
             }
         }
-
         if (isset($preferredTitles[$defaultLanguage])) {
             $preferred = array_shift($preferredTitles[$defaultLanguage]);
+        } elseif (isset($alternateTitles[$defaultLanguage])) {
+            $preferred = array_shift($alternateTitles[$defaultLanguage]);
         } elseif ($preferredTitles) {
             reset($preferredTitles);
             $preferred = array_shift($preferredTitles[key($preferredTitles)]);
-        } elseif (isset($alternateTitles[$defaultLanguage])) {
-            $preferred = array_shift($alternateTitles[$defaultLanguage]);
         } elseif ($alternateTitles) {
             reset($alternateTitles);
             $preferred = array_shift($alternateTitles[key($alternateTitles)]);
@@ -587,7 +602,14 @@ class Lido extends AbstractRecord
             );
             foreach ($nodes as $set) {
                 if ($value = trim((string)($set->descriptiveNoteValue ?? ''))) {
-                    $descriptionWrapDescriptions[] = $value;
+                    if (
+                        $language === null
+                        || $language === $this->metadataUtils->normalizeLanguageCode(
+                            $set->descriptiveNoteValue->attributes()->lang ?? ''
+                        )
+                    ) {
+                        $descriptionWrapDescriptions[] = $value;
+                    }
                 }
             }
             if ($descriptionWrapDescriptions) {
@@ -1513,17 +1535,11 @@ class Lido extends AbstractRecord
                     $this->getIdentifier()
                 );
                 // Add title field if needed:
-                if ($this->getDriverParam('addIdToHierarchyTitle', true)) {
-                    $data['title_in_hierarchy']
-                        = trim($this->getIdentifier() . ' ' . $data['title']);
-                }
+                $this->addHierarchyTitles($data);
             }
         }
-
         // Include hierarchy titles from relatedWorksWrap in allfields:
-        foreach (
-            ['is_hierarchy_title', 'hierarchy_parent_title', 'hierarchy_top_title', 'title_in_hierarchy'] as $field
-        ) {
+        foreach ($this->hierarchyFieldsInAllFields as $field) {
             // phpcs:ignore
             /** @psalm-var list<string> */
             $titles = (array)($data[$field] ?? []);
@@ -1532,6 +1548,31 @@ class Lido extends AbstractRecord
                 ...$titles,
             ];
         }
+    }
+
+    /**
+     * Add hierarchy titles.
+     *
+     * @param array $data Reference to the target array
+     *
+     * @return void
+     */
+    protected function addHierarchyTitles(array &$data): void
+    {
+        if ($this->getDriverParam('addIdToHierarchyTitle', true)) {
+            $data['title_in_hierarchy'] = trim($this->getIdentifier() . ' ' . $data['title']);
+        }
+    }
+
+    /**
+     * Add additional titles (for downstream usage).
+     *
+     * @param array $data Reference to the target array
+     *
+     * @return void
+     */
+    protected function addAdditionalTitles(array &$data): void
+    {
     }
 
     /**

--- a/src/RecordManager/Base/Record/Lido.php
+++ b/src/RecordManager/Base/Record/Lido.php
@@ -1559,6 +1559,7 @@ class Lido extends AbstractRecord
      */
     protected function addHierarchyTitles(array &$data): void
     {
+        // Note: title_in_hierarchy is only needed if it differs from title.
         if ($this->getDriverParam('addIdToHierarchyTitle', true)) {
             $data['title_in_hierarchy'] = trim($this->getIdentifier() . ' ' . $data['title']);
         }

--- a/src/RecordManager/Base/Record/Lido.php
+++ b/src/RecordManager/Base/Record/Lido.php
@@ -148,7 +148,7 @@ class Lido extends AbstractRecord
     ];
 
     /**
-     * Hiearchy fields included in allfields.
+     * Hierarchy fields included in allfields.
      *
      * @var array
      */

--- a/src/RecordManager/Base/Record/Lrmi.php
+++ b/src/RecordManager/Base/Record/Lrmi.php
@@ -63,11 +63,7 @@ class Lrmi extends Qdc
      */
     public function getTitle($forFiling = false)
     {
-        $title = (string)$this->doc->title;
-        if ($forFiling) {
-            $title = $this->metadataUtils->createSortTitle($title);
-        }
-        return $title;
+        return $this->getTitleByLanguage($forFiling);
     }
 
     /**
@@ -99,6 +95,37 @@ class Lrmi extends Qdc
     public function getRawTopicIds(): array
     {
         return $this->getTopicData(true);
+    }
+
+    /**
+     * Return record title by language
+     *
+     * @param bool    $forFiling Whether the title is to be used in filing
+     *                           (e.g. sorting, non-filing characters should be removed)
+     * @param ?string $language  Return title with specific language code (for downstream usage).
+     *                           Otherwise returns first title.
+     *
+     * @return string
+     */
+    protected function getTitleByLanguage($forFiling = false, ?string $language = null): string
+    {
+        $key = __METHOD__ . ($forFiling ? '1' : '0') . ($language ?? '');
+        if (isset($this->resultCache[$key])) {
+            return $this->resultCache[$key];
+        }
+        $titleFirst = $titleLang = '';
+        foreach ($this->doc->title as $t) {
+            $titleFirst = $titleFirst ?: trim((string)$t);
+            if ($language && $this->metadataUtils->normalizeLanguageCode($t->attributes()->lang ?? '') === $language) {
+                $titleLang = trim((string)$t);
+                break;
+            }
+        }
+        $title = $language ? $titleLang : $titleFirst;
+        if ($forFiling) {
+            $title = $this->metadataUtils->createSortTitle($title);
+        }
+        return $this->resultCache[$key] = $title;
     }
 
     /**

--- a/src/RecordManager/Base/Record/Qdc.php
+++ b/src/RecordManager/Base/Record/Qdc.php
@@ -164,27 +164,7 @@ class Qdc extends AbstractRecord
      */
     public function getTitle($forFiling = false)
     {
-        $key = __METHOD__ . ($forFiling ? '1' : '0');
-        if (isset($this->resultCache[$key])) {
-            return $this->resultCache[$key];
-        }
-
-        $preferred = null;
-        $default = '';
-        foreach ($this->doc->title as $title) {
-            if ('' === $default) {
-                $default = (string)$title;
-            }
-            if ((string)($title->attributes()->{'type'}) !== 'alternative') {
-                $preferred = (string)$title;
-                break;
-            }
-        }
-        $result = $forFiling
-            ? $this->metadataUtils->createSortTitle($preferred ?? $default)
-            : $this->metadataUtils->stripTrailingPunctuation($preferred ?? $default);
-
-        return $this->resultCache[$key] = $result;
+        return $this->getTitleByLanguage($forFiling);
     }
 
     /**
@@ -292,6 +272,47 @@ class Qdc extends AbstractRecord
     public function getSeries()
     {
         return [];
+    }
+
+    /**
+     * Return record title by language
+     *
+     * @param bool    $forFiling Whether the title is to be used in filing
+     *                           (e.g. sorting, non-filing characters should be removed)
+     * @param ?string $language  Return title with specific language code (for downstream usage).
+     *                           Otherwise returns first preferred title.
+     *
+     * @return string
+     */
+    protected function getTitleByLanguage($forFiling = false, ?string $language = null): string
+    {
+        $key = __METHOD__ . ($forFiling ? '1' : '0') . ($language ?? '');
+        if (isset($this->resultCache[$key])) {
+            return $this->resultCache[$key];
+        }
+
+        $preferred = null;
+        $default = '';
+        foreach ($this->doc->title as $title) {
+            if (
+                $language
+                && $this->metadataUtils->normalizeLanguageCode($title->attributes()->lang ?? '') !== $language
+            ) {
+                continue;
+            }
+            if ('' === $default) {
+                $default = trim((string)$title);
+            }
+            if ((string)($title->attributes()->{'type'}) !== 'alternative') {
+                $preferred = trim((string)$title);
+                break;
+            }
+        }
+        $result = $forFiling
+            ? $this->metadataUtils->createSortTitle($preferred ?? $default)
+            : $this->metadataUtils->stripTrailingPunctuation($preferred ?? $default);
+
+        return $this->resultCache[$key] = $result;
     }
 
     /**

--- a/src/RecordManager/Base/Splitter/Ead3.php
+++ b/src/RecordManager/Base/Splitter/Ead3.php
@@ -251,7 +251,7 @@ class Ead3 extends Ead
 
         $absolute = $addData->addChild('archive');
         $absolute->addAttribute('id', $this->archiveId);
-        $absolute->addAttribute('title', $this->archiveTitle);
+        $this->addTitleAttributes($absolute, $this->getArchiveTitles());
         $absolute->addAttribute(
             'sequence',
             str_pad((string)$this->currentPos, 7, '0', STR_PAD_LEFT)
@@ -282,28 +282,11 @@ class Ead3 extends Ead
                 }
             }
 
-            $parentTitle = (string)$parentDid->unittitle;
-
-            if (!$parentTitle) {
-                $parentTitle
-                    = (string)$parentDid->unittitle->attributes()->label;
-
-                if (!$parentTitle) {
-                    $parentTitle = $parentID;
-                }
-            }
-
-            if ($this->prependParentTitleWithUnitId) {
-                if ($pid = $this->getParentUnitId($parentDid)) {
-                    $parentTitle = $pid . ' ' . $parentTitle;
-                }
-            }
-
             $parentNode = $original->xpath('parent::*[@level]');
 
             $parent = $addData->addChild('parent');
             $parent->addAttribute('id', $parentID);
-            $parent->addAttribute('title', $parentTitle);
+            $this->addTitleAttributes($parent, $this->getParentTitles($parentDid, $parentID));
             if ($parentNode) {
                 // Add a new parent-node to parent record addData
                 $level = (string)$parentNode[0]->attributes()->level;
@@ -311,7 +294,7 @@ class Ead3 extends Ead
                 if (in_array($level, ['series', 'subseries'])) {
                     $parent = $originalAddData->addChild('parent');
                     $parent->addAttribute('id', $parentID);
-                    $parent->addAttribute('title', $parentTitle);
+                    $this->addTitleAttributes($parent, $this->getParentTitles($parentDid, $parentID));
                     $parent->addAttribute('level', $level);
                 }
             }
@@ -331,9 +314,52 @@ class Ead3 extends Ead
             if ($this->currentPos > 1) {
                 $parent = $addData->addChild('parent');
                 $parent->addAttribute('id', $this->archiveId);
-                $parent->addAttribute('title', $this->archiveTitle);
+                $this->addTitleAttributes($parent, $this->getArchiveTitles());
                 $parent->addAttribute('level', 'archive');
             }
         }
+    }
+
+    /**
+     * Add title attributes to the element
+     *
+     * @param \SimpleXMLElement $element Element
+     * @param array             $titles  Title values
+     *
+     * @return void
+     */
+    protected function addTitleAttributes(\SimpleXMLElement $element, array $titles): void
+    {
+        $element->addAttribute('title', $titles['title']);
+    }
+
+    /**
+     * Get Parent titles as an array
+     *
+     * @param \SimpleXMLElement $parentDid Parent did element
+     * @param string            $parentID  Parent ID to use as fallback
+     *
+     * @return array
+     */
+    protected function getParentTitles(\SimpleXMLElement $parentDid, string $parentID): array
+    {
+
+        $parentTitle
+            = trim((string)($parentDid->unittitle ?? ''))
+            ?: trim((string)($parentDid->unittitle->attributes()->label ?? $parentID));
+        if ($this->prependParentTitleWithUnitId && ($pid = $this->getParentUnitId($parentDid))) {
+            $parentTitle = $pid . ' ' . $parentTitle;
+        }
+        return ['title' => $parentTitle];
+    }
+
+    /**
+     * Get Archive titles as an array
+     *
+     * @return array
+     */
+    protected function getArchiveTitles(): array
+    {
+        return ['title' => $this->archiveTitle];
     }
 }

--- a/src/RecordManager/Base/Utils/MetadataUtils.php
+++ b/src/RecordManager/Base/Utils/MetadataUtils.php
@@ -135,12 +135,7 @@ class MetadataUtils
      *
      * @var array
      */
-    protected $languageCodeMappings = [
-        'fi' => ['fi','fin'],
-        'sv' => ['sv','swe'],
-        'en' => ['en', 'en-gb', 'eng'],
-        'se' => ['se', 'sme'],
-    ];
+    protected $languageCodeMappings = [];
 
     /**
      * Normalization character folding table
@@ -258,6 +253,8 @@ class MetadataUtils
                 }
             }
         }
+
+        $this->languageCodeMappings = $config['Metadata Language Code Mappings'] ?? [];
     }
 
     /**
@@ -472,8 +469,6 @@ class MetadataUtils
      * @param string $a2 LastName FirstName
      *
      * @return bool
-     *
-     * @psalm-suppress InvalidArrayOffset
      */
     public function authorMatch($a1, $a2)
     {
@@ -1092,12 +1087,7 @@ class MetadataUtils
     public function normalizeLanguageCode(string $language): string
     {
         $lang = trim(strtolower($language));
-        foreach ($this->languageCodeMappings as $key => $values) {
-            if (in_array($lang, $values)) {
-                return $key;
-            }
-        }
-        return $lang;
+        return $this->languageCodeMappings[$lang] ?? $lang;
     }
 
     /**

--- a/src/RecordManager/Base/Utils/MetadataUtils.php
+++ b/src/RecordManager/Base/Utils/MetadataUtils.php
@@ -131,6 +131,18 @@ class MetadataUtils
     protected $lowercaseLanguageStrings = true;
 
     /**
+     * Language code mappings
+     *
+     * @var array
+     */
+    protected $languageCodeMappings = [
+        'fi' => ['fi','fin'],
+        'sv' => ['sv','swe'],
+        'en' => ['en', 'en-gb', 'eng'],
+        'se' => ['se', 'sme'],
+    ];
+
+    /**
      * Normalization character folding table
      *
      * @var array
@@ -1066,6 +1078,24 @@ class MetadataUtils
             $languages = strtolower($languages);
         }
         return $languages;
+    }
+
+    /**
+     * Normalize language code.
+     *
+     * @param string $language Language code
+     *
+     * @return string
+     */
+    public function normalizeLanguageCode($language)
+    {
+        $lang = trim(strtolower($language));
+        foreach ($this->languageCodeMappings as $key => $values) {
+            if (in_array($lang, $values)) {
+                return $key;
+            }
+        }
+        return $lang;
     }
 
     /**

--- a/src/RecordManager/Base/Utils/MetadataUtils.php
+++ b/src/RecordManager/Base/Utils/MetadataUtils.php
@@ -1089,7 +1089,7 @@ class MetadataUtils
      *
      * @return string
      */
-    public function normalizeLanguageCode($language)
+    public function normalizeLanguageCode(string $language): string
     {
         $lang = trim(strtolower($language));
         foreach ($this->languageCodeMappings as $key => $values) {

--- a/tests/RecordManagerTest/Base/Record/CreateSampleRecordTrait.php
+++ b/tests/RecordManagerTest/Base/Record/CreateSampleRecordTrait.php
@@ -97,11 +97,14 @@ trait CreateSampleRecordTrait
         array $config = []
     ) {
         $logger = $this->createMock(Logger::class);
-        $metadataConfig = [
-            'Site' => [
-                'articles' => 'articles.lst',
-            ],
-        ];
+        $metadataConfig = array_merge(
+            $config,
+            [
+                'Site' => [
+                    'articles' => 'articles.lst',
+                ],
+            ]
+        );
         $metadataUtils = new \RecordManager\Base\Utils\MetadataUtils(
             $this->getFixtureDir() . 'config/recorddrivertest',
             $metadataConfig,

--- a/tests/RecordManagerTest/Base/Record/Ead3Test.php
+++ b/tests/RecordManagerTest/Base/Record/Ead3Test.php
@@ -237,7 +237,22 @@ class Ead3Test extends RecordTestBase
      */
     public function testGetTitleByLanguage()
     {
-        $record = $this->createRecord(Ead3::class, 'sks.xml');
+        $record = $this->createRecord(
+            Ead3::class,
+            'sks.xml',
+            [],
+            'Base',
+            [],
+            [
+                'Metadata Language Code Mappings' => [
+                    'fin' => 'fi',
+                    'swe' => 'sv',
+                    'en-gb' => 'en',
+                    'eng' => 'en',
+                    'sme' => 'se',
+                ],
+            ],
+        );
         $reflection = new \ReflectionObject($record);
         $getTitleByLanguage = $reflection->getMethod('getTitleByLanguage');
 

--- a/tests/RecordManagerTest/Base/Record/Ead3Test.php
+++ b/tests/RecordManagerTest/Base/Record/Ead3Test.php
@@ -1,0 +1,259 @@
+<?php
+
+/**
+ * EAD3 Record Driver Test Class
+ *
+ * PHP version 5
+ *
+ * Copyright (C) The National Library of Finland 2026.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * @category DataManagement
+ * @package  RecordManager
+ * @author   Minna Rönkä <minna.ronka@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://github.com/NatLibFi/RecordManager
+ */
+
+namespace RecordManagerTest\Base\Record;
+
+use RecordManager\Base\Record\Ead3;
+
+/**
+ * EAD3 Record Driver Test Class
+ *
+ * @category DataManagement
+ * @package  RecordManager
+ * @author   Minna Rönkä <minna.ronka@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://github.com/NatLibFi/RecordManager
+ */
+class Ead3Test extends RecordTestBase
+{
+    /**
+     * Data provider for testSKS
+     *
+     * @return array
+     */
+    public static function sksProvider(): array
+    {
+        return [
+            'addIdToHierarchyTitle=true' => [
+                'true',
+                '1 1 Sundvall Gustaf Edvard S 1:a) 1',
+            ],
+            'addIdToHierarchyTitle=false' => [
+                'false',
+                null,
+            ],
+        ];
+    }
+
+    /**
+     * Test SKS EAD3 record handling
+     *
+     * @param string $addIdToHierarchyTitle    Value for addIdToHierarchyTitle driver param
+     * @param ?array $expectedTitleInHierarchy Expected title_in_hierarchy field contents
+     *
+     * @return void
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('sksProvider')]
+    public function testSKS(string $addIdToHierarchyTitle, ?string $expectedTitleInHierarchy): void
+    {
+        $fields = $this->createRecord(
+            Ead3::class,
+            'sks.xml',
+            [
+                '__unit_test_no_source__' => [
+                    'driverParams' => [
+                        "addIdToHierarchyTitle=$addIdToHierarchyTitle",
+                    ],
+                ],
+            ]
+        )->toSolrArray();
+        unset($fields['fullrecord']);
+        $ltr = "\u{200E}";
+
+        $expected = [
+            'record_format' => 'ead3',
+            'ctrlnum' => [],
+            'allfields' => [
+                'Yksityisaineisto',
+                'SKS:n arkisto, Hallituskatu 1, HKI',
+                '242790397',
+                'xx.xx.1881-xx.xx.1881',
+                'Sundvall Gustaf Edvard S 1:a) 1',
+                'Sundvall Gustaf Edvard S 1:a) 1 swe',
+                '1',
+                's/sundvall_gustaf_edvard/001/00001/00005',
+                'SKS KRA S Sundvall Gustaf Edvard 1: a) 1',
+                'KRA-K-103174062',
+                'A1576669851fpriz',
+                'Suomi',
+                'Aineistotyyppi: Text 5 Styck',
+                'Aineistotyyppi: Text 5 Pieces',
+                'Aineistotyyppi: Teksti, järjestetty 5 Kappaletta',
+                'Sundvall, Gustaf Edvard',
+                'Sundvall, Gustaf Edvard',
+                'Sundvall, Gustaf Edvard',
+                'Ingman, Anders Wilhelm',
+                'Sundvall, Gustaf Edvard',
+                'Teksti',
+                'Text',
+                'Text',
+                'Luvia',
+                'Luvia',
+                'Luvia',
+                'folk tales',
+                'kansansadut',
+                'folksagor',
+                'fairy tales',
+                'sadut',
+                'sagor',
+                'folklore collectors',
+                'perinteenkerääjät',
+                'traditionsinsamlare',
+                'Sundvall, Gustaf Edvard',
+                'Sundwall, Gustaf Edvard',
+                'Sundvall, Gustaf Edvard',
+                'Sundwall, Gustaf Edvard',
+                'Sundvall, Gustaf Edvard',
+                'Sundwall, Gustaf Edvard',
+                'Ingman, Anders Wilhelm',
+                'Ingman, A.W.',
+                'Sundvall, Gustaf Edvard',
+                'Sundwall, Gustaf Edvard',
+                'Tietosisältö',
+                'G. E. Sundvallin tallentama murresatu Luvialta.',
+                'Tietopalvelun tarjoamispaikka',
+                'SKS:n arkisto, Hallituskatu 1, HKI',
+                'Tekninen tyyppi',
+                'Digitaalinen',
+                'Alkuperäisyys',
+                'Kopio',
+                'Digitaalisen aineiston tiedostomuoto',
+                'TIFF - Tagged Image File Format',
+                'Gustaf Edvard Sundvallin kokoelma',
+            ],
+            'description' => 'G. E. Sundvallin tallentama murresatu Luvialta.',
+            'author' => [
+                'Sundvall, Gustaf Edvard',
+                'Sundwall, Gustaf Edvard',
+                'Sundvall, Gustaf Edvard',
+                'Sundwall, Gustaf Edvard',
+                'Sundvall, Gustaf Edvard',
+                'Sundwall, Gustaf Edvard',
+                'Ingman, Anders Wilhelm',
+                'Ingman, A.W.',
+                'Sundvall, Gustaf Edvard',
+                'Sundwall, Gustaf Edvard',
+            ],
+            'author_sort' => 'Sundvall, Gustaf Edvard',
+            'author_corporate' => [],
+            'geographic_facet' => [
+                'Luvia',
+                'Luvia',
+                'Luvia',
+            ],
+            'geographic' => [
+                'Luvia',
+                'Luvia',
+                'Luvia',
+            ],
+            'topic_facet' => [
+                'folk tales',
+                'kansansadut',
+                'folksagor',
+                'fairy tales',
+                'sadut',
+                'sagor',
+                'folklore collectors',
+                'perinteenkerääjät',
+                'traditionsinsamlare',
+            ],
+            'topic' => [
+                'folk tales',
+                'kansansadut',
+                'folksagor',
+                'fairy tales',
+                'sadut',
+                'sagor',
+                'folklore collectors',
+                'perinteenkerääjät',
+                'traditionsinsamlare',
+            ],
+            'format' => 'Teksti',
+            'institution' => 'SKS:n arkisto, Hallituskatu 1, HKI',
+            'series' => 'Tekstit/Gustaf Edvard Sundvallin kokoelma',
+            'title_sub' => '1',
+            'title_short' => 'Sundvall Gustaf Edvard S 1:a) 1',
+            'title' => '1 Sundvall Gustaf Edvard S 1:a) 1',
+            'title_sort' => '1 sundvall gustaf edvard s 1 a 1',
+            'title_full' => '1 Sundvall Gustaf Edvard S 1:a) 1',
+            'language' => [
+                'fin',
+            ],
+            'physical' => [],
+            'thumbnail' => '',
+            'hierarchytype' => 'Default',
+            'hierarchy_top_id' => '237990354',
+            'hierarchy_top_title' => 'Gustaf Edvard Sundvallin kokoelma',
+            'hierarchy_sequence' => '0000003',
+            'hierarchy_parent_id' => '237990354_238008149',
+            'hierarchy_parent_title' => 'Tekstit/Gustaf Edvard Sundvallin kokoelma',
+            'isbn' => [],
+            'issn' => [],
+            'publishDate' => [],
+            'publishDateRange' => [],
+            'publishDateSort' => '',
+            'author2' => [],
+        ];
+        if (null !== $expectedTitleInHierarchy) {
+            $expected['title_in_hierarchy'] = $expectedTitleInHierarchy;
+        }
+
+        $this->assertEquals(
+            $expected,
+            $fields
+        );
+    }
+
+    /**
+     * Test getTitleByLanguage
+     *
+     * @return void
+     */
+    public function testGetTitleByLanguage()
+    {
+        $record = $this->createRecord(Ead3::class, 'sks.xml');
+        $reflection = new \ReflectionObject($record);
+        $getTitleByLanguage = $reflection->getMethod('getTitleByLanguage');
+
+        $this->assertEquals(
+            '1 Sundvall Gustaf Edvard S 1:a) 1',
+            $getTitleByLanguage->invokeArgs($record, [])
+        );
+
+        $this->assertEquals(
+            '1 Sundvall Gustaf Edvard S 1:a) 1 swe',
+            $getTitleByLanguage->invokeArgs($record, [false, 'sv'])
+        );
+
+        $this->assertEquals(
+            '',
+            $getTitleByLanguage->invokeArgs($record, [false, 'en'])
+        );
+    }
+}

--- a/tests/RecordManagerTest/Base/Record/LidoTest.php
+++ b/tests/RecordManagerTest/Base/Record/LidoTest.php
@@ -55,15 +55,11 @@ class LidoTest extends RecordTestBase
 
         $expected = [
             'record_format' => 'lido',
-            'title_full' => 'Luonnonsuojelusäädökset / toimittanut Raimo Luhtanen;'
-                . ' Säädökset',
-            'title_short' => 'Luonnonsuojelusäädökset / toimittanut Raimo Luhtanen;'
-                . ' Säädökset',
-            'title' => 'Luonnonsuojelusäädökset / toimittanut Raimo Luhtanen;'
-                . ' Säädökset',
-            'title_sort' => 'luonnonsuojelusäädökset toimittanut raimo luhtanen'
-                . ' säädökset',
-            'title_alt' => [],
+            'title_full' => 'English Title; English Alt Title',
+            'title_short' => 'English Title; English Alt Title',
+            'title' => 'English Title; English Alt Title',
+            'title_sort' => 'english title english alt title',
+            'title_alt' => ['Luonnonsuojelusäädökset / toimittanut Raimo Luhtanen; Säädökset'],
             'description' => '',
             'format' => 'Kirja',
             'institution' => 'Test Institution',
@@ -104,6 +100,8 @@ class LidoTest extends RecordTestBase
                 'Kirja',
                 'Säädökset',
                 'Luonnonsuojelusäädökset / toimittanut Raimo Luhtanen',
+                'English Title',
+                'English Alt Title',
                 'Test Institution',
                 '26054',
                 '9518593736',
@@ -142,6 +140,10 @@ class LidoTest extends RecordTestBase
                 'titles' => [
                     [
                         'type' => 'title',
+                        'value' => 'English Title; English Alt Title',
+                    ],
+                    [
+                        'type' => 'title',
                         'value' => 'Luonnonsuojelusäädökset / toimittanut Raimo'
                         . ' Luhtanen; Säädökset',
                     ],
@@ -168,6 +170,7 @@ class LidoTest extends RecordTestBase
                     'driverParams' => [
                         'mergeTitleValues=false',
                         'mergeTitleSets=false',
+                        'defaultDisplayLanguage=fi',
                     ],
                 ],
             ]
@@ -183,6 +186,7 @@ class LidoTest extends RecordTestBase
             'title_sort' => 'luonnonsuojelusäädökset toimittanut raimo luhtanen',
             'title_alt' => [
                 'Säädökset',
+                'English Title',
             ],
             'description' => '',
             'format' => 'Kirja',
@@ -224,6 +228,8 @@ class LidoTest extends RecordTestBase
                 'Kirja',
                 'Säädökset',
                 'Luonnonsuojelusäädökset / toimittanut Raimo Luhtanen',
+                'English Title',
+                'English Alt Title',
                 'Test Institution',
                 '26054',
                 '9518593736',
@@ -268,6 +274,10 @@ class LidoTest extends RecordTestBase
                     [
                         'type' => 'title',
                         'value' => 'Säädökset',
+                    ],
+                                        [
+                        'type' => 'title',
+                        'value' => 'English Title',
                     ],
                 ],
                 'titlesAltScript' => [],
@@ -339,6 +349,97 @@ class LidoTest extends RecordTestBase
         ];
 
         $this->compareArray($expected, $keys, 'getWorkIdentificationData');
+    }
+
+    /**
+     * Test getTitles
+     *
+     * @return void
+     */
+    public function testGetTitles()
+    {
+        $record = $this->createRecord(Lido::class, 'lido1.xml');
+        $reflection = new \ReflectionObject($record);
+        $getTitles = $reflection->getMethod('getTitles');
+
+        $this->assertEquals(
+            [
+                'preferred' => 'English Title; English Alt Title',
+                'alternate' => ['Luonnonsuojelusäädökset / toimittanut Raimo Luhtanen; Säädökset'],
+            ],
+            $getTitles->invokeArgs($record, [])
+        );
+        $this->assertEquals(
+            [
+                'preferred' => 'Luonnonsuojelusäädökset / toimittanut Raimo Luhtanen; Säädökset',
+                'alternate' => [],
+            ],
+            $getTitles->invokeArgs($record, ['fi'])
+        );
+        $record = $this->createRecord(
+            Lido::class,
+            'lido1.xml',
+            [
+                '__unit_test_no_source__' => [
+                    'driverParams' => [
+                        'mergeTitleValues=false',
+                    ],
+                ],
+            ]
+        );
+        $this->assertEquals(
+            [
+                'preferred' => 'English Title',
+                'alternate' => [
+                    'Luonnonsuojelusäädökset / toimittanut Raimo Luhtanen',
+                    'English Alt Title',
+                ],
+            ],
+            $getTitles->invokeArgs($record, [])
+        );
+        $this->assertEquals(
+            [
+                'preferred' => 'Luonnonsuojelusäädökset / toimittanut Raimo Luhtanen',
+                'alternate' => [
+                    'Säädökset',
+                ],
+            ],
+            $getTitles->invokeArgs($record, ['fi'])
+        );
+    }
+
+    /**
+     * Test LIDO hierarchy handling
+     *
+     * @return void
+     */
+    public function testLidoHierarchies()
+    {
+        $record = $this->createRecord(
+            Lido::class,
+            'lido_hierarchy.xml',
+            [
+                '__unit_test_no_source__' => [
+                    'driverParams' => [
+                        'indexHierarchies=true',
+                        'addIdToHierarchyTitle=true',
+                        'defaultDisplayLanguage=fi',
+                    ],
+                ],
+            ]
+        );
+        $fields = $record->toSolrArray();
+
+        $this->assertEquals('testit-200', $fields['hierarchy_top_id']);
+        $this->assertEquals('Yksikkötestikokoelma; Kaikki testit kautta aikojen', $fields['hierarchy_top_title']);
+        $this->assertEquals('testit-404', $fields['hierarchy_parent_id']);
+        $this->assertEquals('Puuttuvien testien kokoelma', $fields['hierarchy_parent_title']);
+        $this->assertEquals('testi-000000418', $fields['hierarchy_sequence']);
+        $this->assertEquals('testi-418 Testi joka puuttui', $fields['title_in_hierarchy']);
+        $this->assertContains('Yksikkötestikokoelma; Kaikki testit kautta aikojen', $fields['allfields']);
+        $this->assertContains('Puuttuvien testien kokoelma', $fields['allfields']);
+        $this->assertContains('testi-418 Testi joka puuttui', $fields['allfields']);
+        $this->assertEquals('Testiarkisto', $fields['collection']);
     }
 
     /**

--- a/tests/RecordManagerTest/Base/Record/LidoTest.php
+++ b/tests/RecordManagerTest/Base/Record/LidoTest.php
@@ -49,7 +49,22 @@ class LidoTest extends RecordTestBase
      */
     public function testLido1()
     {
-        $record = $this->createRecord(Lido::class, 'lido1.xml');
+        $record = $this->createRecord(
+            Lido::class,
+            'lido1.xml',
+            [],
+            'Base',
+            [],
+            [
+                'Metadata Language Code Mappings' => [
+                    'fin' => 'fi',
+                    'swe' => 'sv',
+                    'en-gb' => 'en',
+                    'eng' => 'en',
+                    'sme' => 'se',
+                ],
+            ],
+        );
         $fields = $record->toSolrArray();
         unset($fields['fullrecord']);
 
@@ -173,7 +188,18 @@ class LidoTest extends RecordTestBase
                         'defaultDisplayLanguage=fi',
                     ],
                 ],
-            ]
+            ],
+            'Base',
+            [],
+            [
+                'Metadata Language Code Mappings' => [
+                    'fin' => 'fi',
+                    'swe' => 'sv',
+                    'en-gb' => 'en',
+                    'eng' => 'en',
+                    'sme' => 'se',
+                ],
+            ],
         );
         $fields = $record->toSolrArray();
         unset($fields['fullrecord']);
@@ -358,7 +384,22 @@ class LidoTest extends RecordTestBase
      */
     public function testGetTitles()
     {
-        $record = $this->createRecord(Lido::class, 'lido1.xml');
+        $record = $this->createRecord(
+            Lido::class,
+            'lido1.xml',
+            [],
+            'Base',
+            [],
+            [
+                'Metadata Language Code Mappings' => [
+                    'fin' => 'fi',
+                    'swe' => 'sv',
+                    'en-gb' => 'en',
+                    'eng' => 'en',
+                    'sme' => 'se',
+                ],
+            ],
+        );
         $reflection = new \ReflectionObject($record);
         $getTitles = $reflection->getMethod('getTitles');
 
@@ -385,7 +426,18 @@ class LidoTest extends RecordTestBase
                         'mergeTitleValues=false',
                     ],
                 ],
-            ]
+            ],
+            'Base',
+            [],
+            [
+                'Metadata Language Code Mappings' => [
+                    'fin' => 'fi',
+                    'swe' => 'sv',
+                    'en-gb' => 'en',
+                    'eng' => 'en',
+                    'sme' => 'se',
+                ],
+            ],
         );
         $this->assertEquals(
             [

--- a/tests/RecordManagerTest/Base/Record/LrmiTest.php
+++ b/tests/RecordManagerTest/Base/Record/LrmiTest.php
@@ -66,9 +66,9 @@ class LrmiTest extends RecordTestBase
             ],
             'allfields' => [
                 'oai:aoe.fi:11',
+                'Designing Learning Processes',
                 'Opetuksen ja oppimisen suunnittelu, Learning Design',
                 'Planering av undevisning och lärande',
-                'Designing Learning Processes',
                 '2019-12-17T08:51:19Z',
                 'Learning Design – opetuksen ja oppimisen suunnittelu tarkoittaa'
                 . ' sekä opettajan opetuksen suunnittelua ja valmistelua...',
@@ -153,15 +153,15 @@ class LrmiTest extends RecordTestBase
             ],
             'author_corporate' => [],
             'author_sort' => 'Koli, Hanne',
-            'title_full' => 'Opetuksen ja oppimisen suunnittelu, Learning Design',
-            'title' => 'Opetuksen ja oppimisen suunnittelu, Learning Design',
-            'title_short' => 'Opetuksen ja oppimisen suunnittelu, Learning Design',
+            'title_full' => 'Designing Learning Processes',
+            'title' => 'Designing Learning Processes',
+            'title_short' => 'Designing Learning Processes',
             'title_sub' => '',
             'title_alt' => [
+                'Opetuksen ja oppimisen suunnittelu, Learning Design',
                 'Planering av undevisning och lärande',
-                'Designing Learning Processes',
             ],
-            'title_sort' => 'opetuksen ja oppimisen suunnittelu learning design',
+            'title_sort' => 'designing learning processes',
             'publisher' => [],
             'publishDate' => [
                 '2019',
@@ -226,12 +226,12 @@ class LrmiTest extends RecordTestBase
                     [
                         'type' => 'title',
                         'value'
-                            => 'opetuksen ja oppimisen suunnittelu learning design',
+                            => 'designing learning processes',
                     ],
                     [
                         'type' => 'title',
                         'value'
-                            => 'Opetuksen ja oppimisen suunnittelu, Learning Design',
+                            => 'Designing Learning Processes',
                     ],
                 ],
                 'titlesAltScript' => [
@@ -240,5 +240,38 @@ class LrmiTest extends RecordTestBase
         ];
 
         $this->compareArray($expected, $keys, 'getWorkIdentificationData');
+    }
+
+    /**
+     * Test getTitleByLanguage
+     *
+     * @return void
+     */
+    public function testGetTitleByLanguage()
+    {
+        $record = $this->createRecord(
+            Lrmi::class,
+            'lrmi1.xml',
+            [],
+            'Base',
+            [$this->createMock(\RecordManager\Base\Http\HttpService::class)]
+        );
+        $reflection = new \ReflectionObject($record);
+        $getTitleByLanguage = $reflection->getMethod('getTitleByLanguage');
+
+        $this->assertEquals(
+            'Designing Learning Processes',
+            $getTitleByLanguage->invokeArgs($record, [])
+        );
+
+        $this->assertEquals(
+            'Opetuksen ja oppimisen suunnittelu, Learning Design',
+            $getTitleByLanguage->invokeArgs($record, [false, 'fi'])
+        );
+
+        $this->assertEquals(
+            '',
+            $getTitleByLanguage->invokeArgs($record, [false, 'se'])
+        );
     }
 }

--- a/tests/RecordManagerTest/Base/Record/QdcTest.php
+++ b/tests/RecordManagerTest/Base/Record/QdcTest.php
@@ -66,6 +66,9 @@ class QdcTest extends RecordTestBase
             ],
             'allfields' => [
                 'Urine : The potential, value chain and its sustainable management',
+                'Is that even a real title',
+                'Ei',
+                'Joo',
                 'Viskari, Eeva-Liisa',
                 'Lehtoranta, Suvi',
                 'Malila, Riikka',
@@ -115,7 +118,11 @@ class QdcTest extends RecordTestBase
             'title_short' => 'Urine',
             'title_sub' => 'The potential, value chain and its sustainable management',
             'title_sort' => 'urine the potential value chain and its sustainable management',
-            'title_alt' => [],
+            'title_alt' => [
+                'Is that even a real title',
+                'Ei',
+                'Joo',
+            ],
             'publisher' => [
                 'Sanitation Project, Research Institute for Humanity and Nature',
             ],
@@ -231,5 +238,38 @@ class QdcTest extends RecordTestBase
             $fields = $record->toSolrArray();
             $this->assertEquals($format, $fields['format']);
         }
+    }
+
+    /**
+     * Test getTitleByLanguage
+     *
+     * @return void
+     */
+    public function testGetTitleByLanguage()
+    {
+        $record = $this->createRecord(
+            Qdc::class,
+            'qdc1.xml',
+            [],
+            'Base',
+            [$this->createMock(\RecordManager\Base\Http\HttpService::class)]
+        );
+        $reflection = new \ReflectionObject($record);
+        $getTitleByLanguage = $reflection->getMethod('getTitleByLanguage');
+
+        $this->assertEquals(
+            'Urine : The potential, value chain and its sustainable management',
+            $getTitleByLanguage->invokeArgs($record, [])
+        );
+
+        $this->assertEquals(
+            'Joo',
+            $getTitleByLanguage->invokeArgs($record, [false, 'fi'])
+        );
+
+        $this->assertEquals(
+            '',
+            $getTitleByLanguage->invokeArgs($record, [false, 'sv'])
+        );
     }
 }

--- a/tests/fixtures/Base/record/lido1.xml
+++ b/tests/fixtures/Base/record/lido1.xml
@@ -13,8 +13,10 @@
       <objectIdentificationWrap>
         <titleWrap>
           <titleSet>
-            <appellationValue pref="alternate">S&#xE4;&#xE4;d&#xF6;kset</appellationValue>
-            <appellationValue pref="preferred">Luonnonsuojelus&#xE4;&#xE4;d&#xF6;kset / toimittanut Raimo Luhtanen</appellationValue>
+            <appellationValue lang="fi" pref="alternate">S&#xE4;&#xE4;d&#xF6;kset</appellationValue>
+            <appellationValue lang="fi" pref="preferred">Luonnonsuojelus&#xE4;&#xE4;d&#xF6;kset / toimittanut Raimo Luhtanen</appellationValue>
+            <appellationValue lang="en" pref="preferred">English Title</appellationValue>
+            <appellationValue lang="en" pref="alternate">English Alt Title</appellationValue>
           </titleSet>
         </titleWrap>
         <inscriptionsWrap/>

--- a/tests/fixtures/Base/record/lido1.xml
+++ b/tests/fixtures/Base/record/lido1.xml
@@ -14,8 +14,8 @@
         <titleWrap>
           <titleSet>
             <appellationValue lang="fi" pref="alternate">S&#xE4;&#xE4;d&#xF6;kset</appellationValue>
-            <appellationValue lang="fi" pref="preferred">Luonnonsuojelus&#xE4;&#xE4;d&#xF6;kset / toimittanut Raimo Luhtanen</appellationValue>
-            <appellationValue lang="en" pref="preferred">English Title</appellationValue>
+            <appellationValue lang="fin" pref="preferred">Luonnonsuojelus&#xE4;&#xE4;d&#xF6;kset / toimittanut Raimo Luhtanen</appellationValue>
+            <appellationValue lang="en-gb" pref="preferred">English Title</appellationValue>
             <appellationValue lang="en" pref="alternate">English Alt Title</appellationValue>
           </titleSet>
         </titleWrap>

--- a/tests/fixtures/Base/record/lido_hierarchy.xml
+++ b/tests/fixtures/Base/record/lido_hierarchy.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0"?>
+<lidoWrap schemaLocation="http://www.lido-schema.org http://www.lido-schema.org/schema/v1.0/lido-v1.0.xsd">
+  <lido>
+    <lidoRecID type="Test">knp-247394</lidoRecID>
+    <descriptiveMetadata lang="fi">
+      <objectClassificationWrap>
+        <objectWorkTypeWrap>
+          <objectWorkType>
+            <term>Testi</term>
+          </objectWorkType>
+        </objectWorkTypeWrap>
+      </objectClassificationWrap>
+      <objectIdentificationWrap>
+        <titleWrap>
+          <titleSet>
+            <appellationValue lang="fi" pref="preferred">Testi joka puuttui</appellationValue>
+            <appellationValue lang="en" pref="preferred">The test that was missing</appellationValue>
+          </titleSet>
+        </titleWrap>
+        <inscriptionsWrap/>
+        <repositoryWrap>
+          <repositorySet>
+            <repositoryName>
+              <legalBodyName>
+                <appellationValue>Test Institution</appellationValue>
+              </legalBodyName>
+            </repositoryName>
+            <workID type="numero">testi-418</workID>
+          </repositorySet>
+        </repositoryWrap>
+      </objectIdentificationWrap>
+      <objectRelationWrap>
+        <subjectWrap>
+          <subjectSet>
+            <subject>
+              <subjectConcept>
+                <term>yksikkötestit</term>
+              </subjectConcept>
+            </subject>
+          </subjectSet>
+        </subjectWrap>
+        <relatedWorksWrap>
+          <relatedWorkSet>
+            <relatedWork>
+              <displayObject label="Julkaistu teoksessa">Testit kautta aikojen</displayObject>
+            </relatedWork>
+            <relatedWorkRelType>
+              <term>is reproduced in</term>
+            </relatedWorkRelType>
+          </relatedWorkSet>
+          <relatedWorkSet>
+            <relatedWork>
+              <displayObject lang="fi">Testiarkisto</displayObject>
+              <displayObject lang="en">Test Archive</displayObject>
+            </relatedWork>
+            <relatedWorkRelType>
+              <term lang="en">Collection</term>
+              <term lanf="fi">Kokoelma</term>
+            </relatedWorkRelType>
+          </relatedWorkSet>
+          <relatedWorkSet>
+            <relatedWork>
+              <displayObject lang="fi">Yksikk&#xF6;testikokoelma</displayObject>
+              <displayObject lang="en">Unit Test Collection</displayObject>
+            </relatedWork>
+            <relatedWorkRelType>
+              <term>Alakokoelma</term>
+            </relatedWorkRelType>
+          </relatedWorkSet>
+          <relatedWorkSet>
+            <relatedWork>
+              <displayObject>Yksikk&#xF6;testikokoelma; Kaikki testit kautta aikojen</displayObject>
+              <object>
+                <objectWebResource/>
+                <objectID type="local identifier">testit-200</objectID>
+                <objectType>
+                  <conceptID type="URI">http://terminology.lido-schema.org/lido01053</conceptID>
+                  <term>collection</term>
+                </objectType>
+                <objectNote type="objectWorkType">Hankintaer&#xE4;</objectNote>
+              </object>
+            </relatedWork>
+            <relatedWorkRelType>
+              <conceptID type=""/>
+              <term>is part of</term>
+            </relatedWorkRelType>
+          </relatedWorkSet>
+          <relatedWorkSet>
+            <relatedWork>
+              <displayObject>Puuttuvien testien kokoelma</displayObject>
+              <object>
+                <objectWebResource/>
+                <objectID type="local identifier">testit-404</objectID>
+                <objectType>
+                  <conceptID type="URI"/>
+                  <term>parent</term>
+                </objectType>
+                <objectNote type="objectWorkType">Hankintaer&#xE4; (lapsi)</objectNote>
+              </object>
+            </relatedWork>
+            <relatedWorkRelType>
+              <conceptID type=""/>
+              <term>is part of</term>
+            </relatedWorkRelType>
+          </relatedWorkSet>
+        </relatedWorksWrap>
+      </objectRelationWrap>
+      <eventWrap>
+        <eventSet>
+          <event>
+            <eventID type=""/>
+            <eventType>
+              <term>creation</term>
+            </eventType>
+            <eventActor>
+              <actorInRole>
+                <actor>
+                  <actorID type=""/>
+                  <nameActorSet>
+                    <appellationValue>Anni M. K&#xF6;rn&#xE4;</appellationValue>
+                  </nameActorSet>
+                </actor>
+                <roleActor>
+                  <term>Kirjoittajat</term>
+                </roleActor>
+              </actorInRole>
+            </eventActor>
+          </event>
+        </eventSet>
+      </eventWrap>
+    </descriptiveMetadata>
+    <administrativeMetadata lang="fi">
+      <recordWrap>
+        <recordInfoSet>
+          <recordInfoID type="knp">M011-320623</recordInfoID>
+        </recordInfoSet>
+      </recordWrap>
+      <rightsWorkWrap>
+        <rightsWorkSet>
+          <rightsHolder>
+            <legalBodyName>
+              <appellationValue>Test Institution</appellationValue>
+            </legalBodyName>
+          </rightsHolder>
+        </rightsWorkSet>
+      </rightsWorkWrap>
+      <recordWrap>
+        <recordID type="local">247394</recordID>
+        <recordType>
+          <term lang="en">Item</term>
+        </recordType>
+      </recordWrap>
+    </administrativeMetadata>
+  </lido>
+</lidoWrap>

--- a/tests/fixtures/Base/record/lrmi1.xml
+++ b/tests/fixtures/Base/record/lrmi1.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <dc schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
   <id>oai:aoe.fi:11</id>
+  <title lang="en">Designing Learning Processes</title>
   <title lang="fi">Opetuksen ja oppimisen suunnittelu, Learning Design</title>
   <title lang="sv">Planering av undevisning och l&#xE4;rande</title>
-  <title lang="en">Designing Learning Processes</title>
   <date>2019-12-17T08:51:19Z</date>
   <description lang="fi">Learning Design &#x2013; opetuksen ja oppimisen suunnittelu tarkoittaa sek&#xE4; opettajan opetuksen suunnittelua ja valmistelua...</description>
   <description lang="en">Learning Design means planning teaching and student&#x2019;s goal-oriented learning...</description>

--- a/tests/fixtures/Base/record/qdc1.xml
+++ b/tests/fixtures/Base/record/qdc1.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <qualifieddc schemaLocation="http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2006/01/06/dcterms.xsd http://purl.org/dc/elements/1.1/ http://dublincore.org/schemas/xmls/qdc/2006/01/06/dc.xsd">
-  <title lang="fi">Urine : The potential, value chain and its sustainable management</title>
+  <title lang="en">Urine : The potential, value chain and its sustainable management</title>
+  <title lang="en" type="alternative">Is that even a real title</title>
+  <title lang="fi" type="alternative">Ei</title>
+  <title lang="fi">Joo</title>
   <creator>Viskari, Eeva-Liisa</creator>
   <creator>Lehtoranta, Suvi</creator>
   <creator>Malila, Riikka</creator>

--- a/tests/fixtures/Base/record/sks.xml
+++ b/tests/fixtures/Base/record/sks.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0"?>
+<c02 level="file">
+  <did>
+    <didnote encodinganalog="ahaa:AI46">Yksityisaineisto</didnote>
+    <repository encodinganalog="ahaa:AI42">
+      <corpname identifier="102268433">
+        <part lang="fin">SKS:n arkisto, Hallituskatu 1, HKI</part>
+      </corpname>
+    </repository>
+    <daoset>
+      <dao label="1" identifier="242790411" href="http://128.214.12.166/s_24537_0001.tif" linktitle="Tiedosto 1"/>
+      <dao label="2" identifier="242790416" href="http://128.214.12.166/s_24537_0002.tif" linktitle="Tiedosto 2"/>
+      <dao label="3" identifier="242790421" href="http://128.214.12.166/s_24537_0003.tif" linktitle="Tiedosto 3"/>
+      <dao label="4" identifier="242790426" href="http://128.214.12.166/s_24537_0004.tif" linktitle="Tiedosto 4"/>
+      <dao label="5" identifier="242790431" href="http://128.214.12.166/s_24537_0005.tif" linktitle="Tiedosto 5"/>
+      <dao label="" identifier="" href="http://128.214.12.166/actuallyishouldappear.tif" linktitle="Very good filename"/>
+      <descriptivenote>
+        <p>242790397</p>
+      </descriptivenote>
+    </daoset>
+    <unitdate label="Ajallinen kattavuus" normal="1881-uu-uu/1881-uu-uu">xx.xx.1881-xx.xx.1881</unitdate>
+    <unittitle label="Sundvall Gustaf Edvard S 1:a) 1" normal="Sundvall Gustaf Edvard S 1:a) 1" lang="fin">Sundvall Gustaf Edvard S 1:a) 1</unittitle>
+    <unittitle label="Sundvall Gustaf Edvard S 1:a) 1" normal="Sundvall Gustaf Edvard S 1:a) 1" lang="swe">Sundvall Gustaf Edvard S 1:a) 1 swe</unittitle>
+    <unitid label="J&#xE4;rjestysnumero">1</unitid>
+    <unitid label="Tekninen" identifier="238612737"/>
+    <unitid label="Muu tunniste">s/sundvall_gustaf_edvard/001/00001/00005</unitid>
+    <unitid label="Analoginen">SKS KRA S Sundvall Gustaf Edvard 1: a) 1</unitid>
+    <unitid label="Vanha tekninen">KRA-K-103174062</unitid>
+    <unitid label="Viivakoodi">A1576669851fpriz</unitid>
+    <langmaterial>
+      <language langcode="fin">Suomi</language>
+    </langmaterial>
+    <physdesc lang="swe">Aineistotyyppi: Text 5 Styck</physdesc>
+    <physdesc lang="eng">Aineistotyyppi: Text 5 Pieces</physdesc>
+    <physdesc lang="fin">Aineistotyyppi: Teksti, j&#xE4;rjestetty 5 Kappaletta</physdesc>
+  </did>
+  <relations>
+    <relation relationtype="cpfrelation" href="EAC_228204328" arcrole="Luovuttaja">
+      <relationentry localtype="Ensisijainen nimi" lang="fin">Sundvall, Gustaf Edvard</relationentry>
+    </relation>
+    <relation relationtype="cpfrelation" href="EAC_228204328" arcrole="Kirjoittaja">
+      <relationentry localtype="Ensisijainen nimi" lang="fin">Sundvall, Gustaf Edvard</relationentry>
+    </relation>
+    <relation relationtype="cpfrelation" href="EAC_228204328" arcrole="Ker&#xE4;&#xE4;j&#xE4;">
+      <relationentry localtype="Ensisijainen nimi" lang="fin">Sundvall, Gustaf Edvard</relationentry>
+    </relation>
+    <relation relationtype="cpfrelation" href="EAC_228598319" arcrole="Luovuttaja">
+      <relationentry localtype="Ensisijainen nimi" lang="fin">Ingman, Anders Wilhelm</relationentry>
+    </relation>
+    <relation relationtype="cpfrelation" href="EAC_228204328" arcrole="Kokoelmanmuodostaja">
+      <relationentry localtype="Ensisijainen nimi" lang="fin">Sundvall, Gustaf Edvard</relationentry>
+    </relation>
+  </relations>
+  <controlaccess>
+    <genreform encodinganalog="ahaa:AI08">
+      <part lang="fin">Teksti</part>
+      <part lang="swe">Text</part>
+      <part lang="eng">Text</part>
+    </genreform>
+    <geogname relator="Alueellinen kattavuus" lang="eng" source="YSO" identifier="http://www.yso.fi/onto/yso/p105341">
+      <part>Luvia</part>
+    </geogname>
+    <geogname relator="Alueellinen kattavuus" lang="fin" source="YSO" identifier="http://www.yso.fi/onto/yso/p105341">
+      <part>Luvia</part>
+    </geogname>
+    <geogname relator="Alueellinen kattavuus" lang="swe" source="YSO" identifier="http://www.yso.fi/onto/yso/p105341">
+      <part>Luvia</part>
+    </geogname>
+    <subject relator="aihe" source="KOKO" identifier="http://www.yso.fi/onto/koko/p9995" lang="eng">
+      <part>folk tales</part>
+    </subject>
+    <subject relator="aihe" source="KOKO" identifier="http://www.yso.fi/onto/koko/p9995" lang="fin">
+      <part>kansansadut</part>
+    </subject>
+    <subject relator="aihe" source="KOKO" identifier="http://www.yso.fi/onto/koko/p9995" lang="swe">
+      <part>folksagor</part>
+    </subject>
+    <subject relator="aihe" source="KOKO" identifier="http://www.yso.fi/onto/koko/p16542" lang="eng">
+      <part>fairy tales</part>
+    </subject>
+    <subject relator="aihe" source="KOKO" identifier="http://www.yso.fi/onto/koko/p16542" lang="fin">
+      <part>sadut</part>
+    </subject>
+    <subject relator="aihe" source="KOKO" identifier="http://www.yso.fi/onto/koko/p16542" lang="swe">
+      <part>sagor</part>
+    </subject>
+    <subject relator="asiasana" source="KOKO" identifier="http://www.yso.fi/onto/koko/p74073" lang="eng">
+      <part>folklore collectors</part>
+    </subject>
+    <subject relator="asiasana" source="KOKO" identifier="http://www.yso.fi/onto/koko/p74073" lang="fin">
+      <part>perinteenker&#xE4;&#xE4;j&#xE4;t</part>
+    </subject>
+    <subject relator="asiasana" source="KOKO" identifier="http://www.yso.fi/onto/koko/p74073" lang="swe">
+      <part>traditionsinsamlare</part>
+    </subject>
+    <name localtype="http://www.rdaregistry.info/Elements/u/#P60401" relator="Luovuttaja" identifier="EAC_228204328">
+      <part localtype="Ensisijainen nimi" lang="fin">Sundvall, Gustaf Edvard</part>
+      <part localtype="Varianttinimi" lang="fin">Sundwall, Gustaf Edvard</part>
+    </name>
+    <name localtype="http://www.rdaregistry.info/Elements/u/#P60434" relator="Kirjoittaja" identifier="EAC_228204328">
+      <part localtype="Ensisijainen nimi" lang="fin">Sundvall, Gustaf Edvard</part>
+      <part localtype="Varianttinimi" lang="fin">Sundwall, Gustaf Edvard</part>
+    </name>
+    <name localtype="http://www.rdaregistry.info/Elements/w/#P10055" relator="Ker&#xE4;&#xE4;j&#xE4;" identifier="EAC_228204328">
+      <part localtype="Ensisijainen nimi" lang="fin">Sundvall, Gustaf Edvard</part>
+      <part localtype="Varianttinimi" lang="fin">Sundwall, Gustaf Edvard</part>
+    </name>
+    <name localtype="http://www.rdaregistry.info/Elements/u/#P60401" relator="Luovuttaja" identifier="EAC_228598319">
+      <part localtype="Ensisijainen nimi" lang="fin">Ingman, Anders Wilhelm</part>
+      <part localtype="Varianttinimi" lang="fin">Ingman, A.W.</part>
+    </name>
+    <name localtype="http://www.rdaregistry.info/Elements/u/#P60066" relator="Kokoelmanmuodostaja" identifier="EAC_228204328">
+      <part localtype="Ensisijainen nimi" lang="fin">Sundvall, Gustaf Edvard</part>
+      <part localtype="Varianttinimi" lang="fin">Sundwall, Gustaf Edvard</part>
+    </name>
+  </controlaccess>
+  <scopecontent>
+    <head>Tietosis&#xE4;lt&#xF6;</head>
+    <p lang="fin">G. E. Sundvallin tallentama murresatu Luvialta.</p>
+  </scopecontent>
+  <altformavail encodinganalog="isadg:3.5.2">
+    <altformavail id="242790397">
+      <list>
+        <defitem>
+          <label>Tietopalvelun tarjoamispaikka</label>
+          <item>SKS:n arkisto, Hallituskatu 1, HKI</item>
+        </defitem>
+        <defitem>
+          <label>Tekninen tyyppi</label>
+          <item>Digitaalinen</item>
+        </defitem>
+        <defitem>
+          <label>Alkuper&#xE4;isyys</label>
+          <item>Kopio</item>
+        </defitem>
+        <defitem>
+          <label>Digitaalisen aineiston tiedostomuoto</label>
+          <item>TIFF - Tagged Image File Format</item>
+        </defitem>
+      </list>
+    </altformavail>
+  </altformavail>
+  <add-data identifier="237990354_238612737">
+    <archive id="237990354" title="Gustaf Edvard Sundvallin kokoelma" sequence="0000003"/>
+    <parent id="237990354_238008149" title="Tekstit/Gustaf Edvard Sundvallin kokoelma" level="series"/>
+  </add-data>
+</c02>


### PR DESCRIPTION
Enable adding language-specific title fields in downstream implementation
- EAD3, LIDO, LRMI, QDC: Add support for getting titles by language
- EAD3, LIDO: Separate function for adding hierarchy titles
- EAD3: Separate function for adding add-data title attributes