### PR TITLE
Fix solr compare records output

### DIFF
--- a/src/RecordManager/Base/Solr/SolrComparer.php
+++ b/src/RecordManager/Base/Solr/SolrComparer.php
@@ -223,10 +223,9 @@ class SolrComparer extends SolrUpdater
             'allfields', 'allfields_unstemmed', 'fulltext', 'fulltext_unstemmed',
             'spelling', 'spellingShingle', 'authorStr', 'author_facet',
             'publisherStr', 'publishDateSort', 'hierarchy_browse',
-            'first_indexed', 'last_indexed', '_version_', 'catalog_date',
+            'first_indexed', 'last_indexed', '_version_',
             'fullrecord', 'title_full_unstemmed', 'title_fullStr',
-            'title_txtP', 'container_title_str_mv', 'author_additionalStr',
-            'callnumber-search', 'series_key_str_mv', 'series_order_str',
+            'title_txtP', 'callnumber-search', 'author_additionalStr',
         ];
 
         if (isset($this->config['Solr']['ignore_in_comparison'])) {

--- a/src/RecordManager/Base/Solr/SolrComparer.php
+++ b/src/RecordManager/Base/Solr/SolrComparer.php
@@ -223,9 +223,10 @@ class SolrComparer extends SolrUpdater
             'allfields', 'allfields_unstemmed', 'fulltext', 'fulltext_unstemmed',
             'spelling', 'spellingShingle', 'authorStr', 'author_facet',
             'publisherStr', 'publishDateSort', 'hierarchy_browse',
-            'first_indexed', 'last_indexed', '_version_',
+            'first_indexed', 'last_indexed', '_version_', 'catalog_date',
             'fullrecord', 'title_full_unstemmed', 'title_fullStr',
-            'author_additionalStr',
+            'title_txtP', 'container_title_str_mv', 'author_additionalStr',
+            'callnumber-search', 'series_key_str_mv', 'series_order_str',
         ];
 
         if (isset($this->config['Solr']['ignore_in_comparison'])) {

--- a/src/RecordManager/Base/Solr/SolrComparer.php
+++ b/src/RecordManager/Base/Solr/SolrComparer.php
@@ -295,7 +295,7 @@ class SolrComparer extends SolrUpdater
             }
         }
         if ($differences) {
-            $msg = "Record {$record['id']} would be changed: " . PHP_EOL
+            $msg = "Record {$record['id']} would be changed:" . PHP_EOL
                 . $differences . PHP_EOL;
             if (!$logFile) {
                 $this->log->writeConsole($msg);


### PR DESCRIPTION
Running `./console solr:compare-records` after indexing a direct file import and importing them again via the same file results in displaying excessive changes. It seems like some fields are created internally by Solr whilst indexing and those do not exist from RecordManager's view for some reason.