### PR TITLE
GeniePlus: fix Guzzle error handling.

### DIFF
--- a/src/RecordManager/Base/Harvest/GeniePlus.php
+++ b/src/RecordManager/Base/Harvest/GeniePlus.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (c) Villanova University 2022.
+ * Copyright (c) Villanova University 2022-2026.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -401,7 +401,11 @@ class GeniePlus extends AbstractBase
         for ($try = 1; $try <= $maxTries; $try++) {
             $this->infoMsg("Sending request: $url");
             try {
-                $response = $client->get($url, compact('headers'));
+                try {
+                    $response = $client->get($url, compact('headers'));
+                } catch (\GuzzleHttp\Exception\BadResponseException $e) {
+                    $response = $e->getResponse();
+                }
                 $code = $response->getStatusCode();
                 if ($code == 404) {
                     return $response;

--- a/src/RecordManager/Base/Harvest/GeniePlus.php
+++ b/src/RecordManager/Base/Harvest/GeniePlus.php
@@ -180,6 +180,7 @@ class GeniePlus extends AbstractBase
      * @var array
      */
     protected $httpOptions = [
+        'http_errors' => false,
         'timeout' => 600,
     ];
 
@@ -401,11 +402,7 @@ class GeniePlus extends AbstractBase
         for ($try = 1; $try <= $maxTries; $try++) {
             $this->infoMsg("Sending request: $url");
             try {
-                try {
-                    $response = $client->get($url, compact('headers'));
-                } catch (\GuzzleHttp\Exception\BadResponseException $e) {
-                    $response = $e->getResponse();
-                }
+                $response = $client->get($url, compact('headers'));
                 $code = $response->getStatusCode();
                 if ($code == 404) {
                     return $response;


### PR DESCRIPTION
When attempting a GeniePlus reharvest after upgrading to the latest RecordManager, I discovered that OAuth renewals were not working correctly because Laminas HTTP error handling differs from Guzzle HTTP error handling. This PR fixes the problem -- it may be worth reviewing whether any other drivers have similar problems.

TODO
- [x] Run local test to confirm refactored code still works before merging